### PR TITLE
Fix 16-bit JP2 crosshatch/black screen rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
 node_modules/
 dist/
 .env
+
+# Test artifacts
+test-results/
+playwright-report/
+
+# Build cache
+.vite/
+*.tsbuildinfo
+
+# AI tools
 .gemini/tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ dist/
 test-results/
 playwright-report/
 
+# Sample JP2 files (large binaries)
+public/*.jp2
+
 # Build cache
 .vite/
 *.tsbuildinfo

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OpenLayers JP2 Viewer</title>
+  <style>
+    html, body, #map {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "@abasb75/openjpeg": "^2.5.3",
-        "ol": "^10.8.0"
+        "ol": "^10.8.0",
+        "proj4": "^2.20.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
+        "@types/proj4": "^2.5.6",
         "typescript": "^5.9.3",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@abasb75/openjpeg": {
@@ -464,11 +468,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@petamoriken/float16": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -820,10 +847,42 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/proj4": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.6.tgz",
+      "integrity": "sha512-zfMrPy9fx+8DchqM0kIUGeu2tTVB5ApO1KGAYcSGFS8GoqRIkyL41xq2yCx/iV3sOLzo7v4hEgViSLTiPI1L0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -832,6 +891,117 @@
       "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
       "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
       "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@zarrita/storage": {
       "version": "0.1.4",
@@ -843,11 +1013,38 @@
         "unzipit": "1.4.3"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/earcut": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -889,6 +1086,26 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -955,6 +1172,22 @@
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
       "license": "Apache-2.0"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -982,6 +1215,17 @@
       "dependencies": {
         "fflate": "^0.8.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/ol": {
       "version": "10.8.0",
@@ -1011,6 +1255,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pbf": {
@@ -1045,6 +1296,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -1072,6 +1370,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proj4": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.20.2.tgz",
+      "integrity": "sha512-ipfBRfQly0HhHTO7hnC1GfaX8bvroO7VV4KH889ehmADSE8C/qzp2j+Jj6783S9Tj6c2qX/hhYm7oH0kgXzBAA==",
+      "license": "MIT",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.5.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ahocevar"
       }
     },
     "node_modules/protocol-buffers-schema": {
@@ -1167,6 +1478,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1175,6 +1493,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1192,6 +1541,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1301,11 +1660,112 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.5.2.tgz",
+      "integrity": "sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==",
+      "license": "MIT"
     },
     "node_modules/xml-utils": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "vitest run --exclude tests/**"
   },
   "keywords": [],
   "author": "",
@@ -15,10 +17,14 @@
   "type": "commonjs",
   "dependencies": {
     "@abasb75/openjpeg": "^2.5.3",
-    "ol": "^10.8.0"
+    "ol": "^10.8.0",
+    "proj4": "^2.20.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "@types/proj4": "^2.5.6",
     "typescript": "^5.9.3",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    baseURL: 'http://172.20.177.66:5173/',
+    headless: true,
+  },
+});

--- a/src/debug-panel.ts
+++ b/src/debug-panel.ts
@@ -1,0 +1,168 @@
+import Map from 'ol/Map';
+import { toLonLat } from 'ol/proj';
+import type { TileProviderInfo } from './tile-provider';
+
+const STYLE = `
+.debug-panel {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #0f0;
+  font-family: monospace;
+  font-size: 11px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  z-index: 9999;
+  max-width: 420px;
+  line-height: 1.5;
+  pointer-events: auto;
+  user-select: text;
+}
+.debug-panel.hidden { display: none; }
+.debug-panel table { border-collapse: collapse; }
+.debug-panel td { padding: 1px 6px 1px 0; white-space: nowrap; }
+.debug-panel td:first-child { color: #aaa; }
+.debug-panel .section { color: #ff0; margin-top: 6px; margin-bottom: 2px; font-weight: bold; }
+.debug-panel .close-btn {
+  position: absolute; top: 4px; right: 8px;
+  cursor: pointer; color: #888; font-size: 14px;
+}
+.debug-panel .close-btn:hover { color: #fff; }
+`;
+
+function fmt(n: number | undefined, digits = 2): string {
+  return n == null ? '—' : n.toFixed(digits);
+}
+
+export function createDebugPanel(map: Map, info: TileProviderInfo): void {
+  // Inject styles
+  const style = document.createElement('style');
+  style.textContent = STYLE;
+  document.head.appendChild(style);
+
+  // Create panel
+  const panel = document.createElement('div');
+  panel.className = 'debug-panel hidden';
+  document.body.appendChild(panel);
+
+  const view = map.getView();
+  const projCode = view.getProjection().getCode();
+  const isPixelMode = projCode === 'jp2-image';
+
+  // State
+  let cursorView = [0, 0] as [number, number];
+  let cursorLonLat = [0, 0] as [number, number];
+  let zoom = view.getZoom() ?? 0;
+  let resolution = view.getResolution() ?? 0;
+  let center = view.getCenter() ?? [0, 0];
+  let extent = view.calculateExtent(map.getSize());
+  let layers = buildLayerList();
+
+  function buildLayerList(): string[] {
+    const result: string[] = [];
+    map.getLayers().forEach((l) => {
+      const name = l.get('name') || l.constructor.name;
+      const vis = l.getVisible() ? '✓' : '✗';
+      const op = (l.getOpacity() * 100).toFixed(0);
+      result.push(`${vis} ${name} (${op}%)`);
+    });
+    return result;
+  }
+
+  function render() {
+    const geoSection = info.geoInfo
+      ? `<div class="section">JP2 Geo</div>
+         <table>
+           <tr><td>EPSG</td><td>${info.geoInfo.epsgCode}</td></tr>
+           <tr><td>Origin</td><td>${fmt(info.geoInfo.originX, 4)}, ${fmt(info.geoInfo.originY, 4)}</td></tr>
+           <tr><td>Pixel Scale</td><td>${fmt(info.geoInfo.pixelScaleX, 6)}, ${fmt(info.geoInfo.pixelScaleY, 6)}</td></tr>
+         </table>`
+      : '';
+
+    panel.innerHTML = `
+      <span class="close-btn" id="debug-close">&times;</span>
+      <div class="section">Cursor</div>
+      <table>
+        <tr><td>View (${projCode})</td><td>${fmt(cursorView[0], 2)}, ${fmt(cursorView[1], 2)}</td></tr>
+        ${isPixelMode ? '' : `<tr><td>Lon/Lat</td><td>${fmt(cursorLonLat[0], 6)}, ${fmt(cursorLonLat[1], 6)}</td></tr>`}
+      </table>
+      <div class="section">View</div>
+      <table>
+        <tr><td>Projection</td><td>${projCode}${isPixelMode ? ' (pixel)' : ''}</td></tr>
+        <tr><td>Zoom</td><td>${fmt(zoom, 3)}</td></tr>
+        <tr><td>Resolution</td><td>${fmt(resolution, 6)} ${isPixelMode ? 'px/px' : 'units/px'}</td></tr>
+        <tr><td>Center</td><td>${fmt(center[0], 2)}, ${fmt(center[1], 2)}</td></tr>
+        <tr><td>Extent</td><td>${extent.map((v) => fmt(v, 1)).join(', ')}</td></tr>
+      </table>
+      <div class="section">Layers</div>
+      <table>${layers.map((l) => `<tr><td colspan="2">${l}</td></tr>`).join('')}</table>
+      <div class="section">JP2 Image</div>
+      <table>
+        <tr><td>Size</td><td>${info.width} × ${info.height}</td></tr>
+        <tr><td>Tile</td><td>${info.tileWidth} × ${info.tileHeight}</td></tr>
+        <tr><td>Grid</td><td>${info.tilesX} × ${info.tilesY}</td></tr>
+        <tr><td>MaxDecodeLevel</td><td>${info.maxDecodeLevel}</td></tr>
+        <tr><td>Components</td><td>${info.componentCount}</td></tr>
+      </table>
+      ${geoSection}
+    `;
+    panel.querySelector('#debug-close')!.addEventListener('click', toggle);
+  }
+
+  function toggle() {
+    panel.classList.toggle('hidden');
+  }
+
+  // Keyboard shortcut
+  document.addEventListener('keydown', (e) => {
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    if (e.key === 'D' || e.key === 'd') toggle();
+  });
+
+  // Pointer move
+  map.on('pointermove', (e) => {
+    cursorView = e.coordinate as [number, number];
+    if (!isPixelMode) {
+      try {
+        const ll = toLonLat(e.coordinate, projCode);
+        cursorLonLat = ll as [number, number];
+      } catch {
+        cursorLonLat = [0, 0];
+      }
+    }
+    if (!panel.classList.contains('hidden')) render();
+  });
+
+  // View changes
+  view.on('change:resolution', () => {
+    zoom = view.getZoom() ?? 0;
+    resolution = view.getResolution() ?? 0;
+    extent = view.calculateExtent(map.getSize());
+    if (!panel.classList.contains('hidden')) render();
+  });
+
+  view.on('change:center', () => {
+    center = view.getCenter() ?? [0, 0];
+    extent = view.calculateExtent(map.getSize());
+    if (!panel.classList.contains('hidden')) render();
+  });
+
+  // Layer changes
+  map.getLayers().on('change:length', () => {
+    layers = buildLayerList();
+    if (!panel.classList.contains('hidden')) render();
+  });
+  map.getLayers().forEach((l) => {
+    l.on('change:visible', () => {
+      layers = buildLayerList();
+      if (!panel.classList.contains('hidden')) render();
+    });
+    l.on('change:opacity', () => {
+      layers = buildLayerList();
+      if (!panel.classList.contains('hidden')) render();
+    });
+  });
+
+  render();
+}

--- a/src/decode-worker.ts
+++ b/src/decode-worker.ts
@@ -1,0 +1,48 @@
+import { decode } from '@abasb75/openjpeg';
+import type { DecodedOpenJPEG } from '@abasb75/openjpeg/types';
+import { decodedBufferToRGBA, computeMinMax } from './pixel-conversion';
+
+export interface DecodeRequest {
+  id: number;
+  codestream: ArrayBuffer;
+  decodeLevel?: number;
+  minValue?: number;
+  maxValue?: number;
+  statsOnly?: boolean;
+}
+
+export interface DecodeResponse {
+  id: number;
+  data?: ArrayBuffer; // RGBA transferable
+  width?: number;
+  height?: number;
+  error?: string;
+  stats?: { min: number; max: number };
+}
+
+self.onmessage = async (e: MessageEvent<DecodeRequest>) => {
+  const { id, codestream, decodeLevel, minValue, maxValue, statsOnly } = e.data;
+  try {
+    const result: DecodedOpenJPEG = await decode(
+      codestream,
+      decodeLevel != null ? { decodeLevel } : undefined,
+    );
+
+    const { width, height, componentCount, bitsPerSample } = result.frameInfo;
+
+    if (statsOnly) {
+      const stats = computeMinMax(result.decodedBuffer, width * height, componentCount, bitsPerSample);
+      const resp: DecodeResponse = { id, width, height, stats: stats ?? undefined };
+      (self as unknown as Worker).postMessage(resp);
+      return;
+    }
+
+    const rgba = decodedBufferToRGBA(result.decodedBuffer, width, height, componentCount, bitsPerSample, minValue, maxValue);
+
+    const resp: DecodeResponse = { id, data: rgba.buffer, width, height };
+    (self as unknown as Worker).postMessage(resp, [rgba.buffer]);
+  } catch (err: any) {
+    const resp: DecodeResponse = { id, error: err?.message ?? String(err) };
+    (self as unknown as Worker).postMessage(resp);
+  }
+};

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,92 +1,67 @@
-import OpenJPEGWASM from '@abasb75/openjpeg';
+import { decode } from '@abasb75/openjpeg';
+import type { DecodedOpenJPEG } from '@abasb75/openjpeg/types';
+import { decodedBufferToRGBA } from './pixel-conversion';
 
-export interface JP2Metadata {
+export interface DecodeResult {
+  data: Uint8ClampedArray;
   width: number;
   height: number;
-  numComponents: number;
-  precision: number;
-  isTiled: boolean;
-  tileSize?: { width: number; height: number };
 }
 
 export class JP2Decoder {
-  private openjpegjs: any = null;
-
   /**
-   * Initializes the WASM decoder.
+   * Decodes a JPEG2000 bitstream into RGBA pixel data.
    */
-  async init(): Promise<void> {
-    if (this.openjpegjs) return;
+  async decode(data: ArrayBuffer, decodeLevel?: number, minValue?: number, maxValue?: number): Promise<DecodeResult> {
+    const result: DecodedOpenJPEG = await decode(data, decodeLevel != null ? { decodeLevel } : undefined);
 
-    console.log('Loading JP2 WASM module (@abasb75/openjpeg)...');
-    try {
-      this.openjpegjs = await OpenJPEGWASM();
-      console.log('JP2 WASM module loaded successfully.');
-    } catch (error) {
-      console.error('Failed to load JP2 WASM module:', error);
-      throw error;
-    }
+    const { width, height, componentCount, bitsPerSample } = result.frameInfo;
+    const rgba = decodedBufferToRGBA(result.decodedBuffer, width, height, componentCount, bitsPerSample, minValue, maxValue);
+    console.log(`JP2 decoded: ${width}x${height}, ${componentCount}ch, ${bitsPerSample}bps`);
+    return { data: rgba, width, height };
   }
 
   /**
-   * Decodes a JPEG2000 bitstream into raw RGBA data.
+   * Decodes a single tile by combining a patched mainHeader + tileData + EOC.
    */
-  async decode(data: ArrayBuffer): Promise<Uint8ClampedArray> {
-    if (!this.openjpegjs) {
-      throw new Error('Decoder not initialized. Call init() first.');
-    }
+  async decodeTile(
+    mainHeader: Uint8Array,
+    tileData: Uint8Array,
+    tileCol: number,
+    tileRow: number,
+    tileWidth: number,
+    tileHeight: number,
+    imageWidth: number,
+    imageHeight: number,
+    tilesX: number,
+  ): Promise<DecodeResult> {
+    const actualW = Math.min(tileWidth, imageWidth - tileCol * tileWidth);
+    const actualH = Math.min(tileHeight, imageHeight - tileRow * tileHeight);
 
-    const decoder = new this.openjpegjs.J2KDecoder();
-    try {
-      // Copy encoded data to WASM memory
-      const encodedBuffer = decoder.getEncodedBuffer(data.byteLength);
-      encodedBuffer.set(new Uint8Array(data));
+    const header = new Uint8Array(mainHeader);
+    const hv = new DataView(header.buffer, header.byteOffset, header.byteLength);
 
-      // Decode the JP2 data
-      decoder.decode();
+    const sizOffset = 4;
+    const xsizOff = sizOffset + 4;
+    hv.setUint32(xsizOff, actualW, false);
+    hv.setUint32(xsizOff + 4, actualH, false);
+    hv.setUint32(xsizOff + 8, 0, false);
+    hv.setUint32(xsizOff + 12, 0, false);
+    hv.setUint32(xsizOff + 16, actualW, false);
+    hv.setUint32(xsizOff + 20, actualH, false);
+    hv.setUint32(xsizOff + 24, 0, false);
+    hv.setUint32(xsizOff + 28, 0, false);
 
-      // Get frame information
-      const frameInfo = decoder.getFrameInfo();
-      const { width, height, components } = frameInfo;
+    const tile = new Uint8Array(tileData);
+    const tv = new DataView(tile.buffer, tile.byteOffset, tile.byteLength);
+    tv.setUint16(4, 0, false);
 
-      // Get the decoded buffer (raw pixel data)
-      const decodedBuffer = decoder.getDecodedBuffer();
-      const decodedArray = new Uint8Array(decodedBuffer);
+    const eoc = new Uint8Array([0xFF, 0xD9]);
+    const codestream = new Uint8Array(header.length + tile.length + 2);
+    codestream.set(header, 0);
+    codestream.set(tile, header.length);
+    codestream.set(eoc, header.length + tile.length);
 
-      // Convert to RGBA if it's not already
-      // OpenJPEG usually decodes into component-interleaved or planar formats
-      // For simplicity in this provider, we assume it's RGB and convert to RGBA
-      const rgba = new Uint8ClampedArray(width * height * 4);
-      
-      if (components.length === 3) {
-        // Simple RGB to RGBA conversion
-        for (let i = 0; i < width * height; i++) {
-          rgba[i * 4] = decodedArray[i * 3];     // R
-          rgba[i * 4 + 1] = decodedArray[i * 3 + 1]; // G
-          rgba[i * 4 + 2] = decodedArray[i * 3 + 2]; // B
-          rgba[i * 4 + 3] = 255;                 // A
-        }
-      } else if (components.length === 1) {
-        // Grayscale to RGBA conversion
-        for (let i = 0; i < width * height; i++) {
-          const val = decodedArray[i];
-          rgba[i * 4] = val;
-          rgba[i * 4 + 1] = val;
-          rgba[i * 4 + 2] = val;
-          rgba[i * 4 + 3] = 255;
-        }
-      } else if (components.length === 4) {
-        // Already RGBA (or CMYK, but we'll assume RGBA)
-        rgba.set(decodedArray);
-      }
-
-      return rgba;
-    } catch (error) {
-      console.error('Decoding failed:', error);
-      throw error;
-    } finally {
-      // Free the decoder instance
-      decoder.delete();
-    }
+    return this.decode(codestream.buffer);
   }
 }

--- a/src/jp2-parser.ts
+++ b/src/jp2-parser.ts
@@ -194,6 +194,7 @@ function parseGeoTIFF(data: Uint8Array): GeoInfo | undefined {
 
   // Extract EPSG from GeoKeys
   let epsgCode = 0;
+  let isGeographic = false;
   if (geoKeys && geoKeys.length >= 4) {
     const numKeys = geoKeys[3];
     for (let k = 0; k < numKeys; k++) {
@@ -204,8 +205,13 @@ function parseGeoTIFF(data: Uint8Array): GeoInfo | undefined {
       // const count = geoKeys[base + 2];
       const value = geoKeys[base + 3];
       // ProjectedCSTypeGeoKey=3072, GeographicTypeGeoKey=2048
-      if ((keyId === 3072 || keyId === 2048) && tiffTagLoc === 0 && value > 0) {
+      if (keyId === 2048 && tiffTagLoc === 0 && value > 0) {
         epsgCode = value;
+        isGeographic = true;
+      }
+      if (keyId === 3072 && tiffTagLoc === 0 && value > 0) {
+        epsgCode = value;
+        isGeographic = false;
       }
     }
   }
@@ -216,16 +222,27 @@ function parseGeoTIFF(data: Uint8Array): GeoInfo | undefined {
   }
 
   // Tiepoint: [I, J, K, X, Y, Z] — pixel (I,J) maps to CRS (X,Y)
-  const originX = tiepoint[3] - tiepoint[0] * pixelScale[0];
-  const originY = tiepoint[4] + tiepoint[1] * pixelScale[1];
+  let originX = tiepoint[3] - tiepoint[0] * pixelScale[0];
+  let originY = tiepoint[4] + tiepoint[1] * pixelScale[1];
+  let scaleX = pixelScale[0];
+  let scaleY = pixelScale[1];
 
-  console.log(`GeoJP2: EPSG:${epsgCode}, origin=(${originX}, ${originY}), scale=(${pixelScale[0]}, ${pixelScale[1]})`);
+  // For geographic CRS (e.g. EPSG:4326), GeoTIFF tiepoints may store
+  // lat/lon order. Detect and swap if originY is out of latitude range
+  // but originX is within latitude range.
+  if (isGeographic && Math.abs(originY) > 90 && Math.abs(originX) <= 90) {
+    console.log('GeoJP2: detected lat/lon axis swap, correcting...');
+    [originX, originY] = [originY, originX];
+    [scaleX, scaleY] = [scaleY, scaleX];
+  }
+
+  console.log(`GeoJP2: EPSG:${epsgCode}, origin=(${originX}, ${originY}), scale=(${scaleX}, ${scaleY}), geographic=${isGeographic}`);
 
   return {
     originX,
     originY,
-    pixelScaleX: pixelScale[0],
-    pixelScaleY: pixelScale[1],
+    pixelScaleX: scaleX,
+    pixelScaleY: scaleY,
     epsgCode,
   };
 }

--- a/src/jp2-parser.ts
+++ b/src/jp2-parser.ts
@@ -1,0 +1,471 @@
+export interface TileIndex {
+  tileId: number;
+  offset: number;     // absolute file offset
+  length: number;     // tile-part byte count (Psot)
+}
+
+export interface GeoInfo {
+  originX: number;       // top-left X in CRS units
+  originY: number;       // top-left Y in CRS units
+  pixelScaleX: number;   // CRS units per pixel (X)
+  pixelScaleY: number;   // CRS units per pixel (Y)
+  epsgCode: number;      // EPSG code (e.g. 4326, 3857, 5186)
+}
+
+export interface JP2Info {
+  width: number;
+  height: number;
+  tileWidth: number;
+  tileHeight: number;
+  tilesX: number;
+  tilesY: number;
+  componentCount: number;
+  mainHeader: Uint8Array;  // cached for reuse
+  tiles: TileIndex[];
+  geoInfo?: GeoInfo;
+}
+
+async function fetchRange(url: string, start: number, end: number): Promise<ArrayBuffer> {
+  const resp = await fetch(url, {
+    headers: { Range: `bytes=${start}-${end}` },
+  });
+  if (!resp.ok && resp.status !== 206) {
+    throw new Error(`Range request failed: ${resp.status}`);
+  }
+  return resp.arrayBuffer();
+}
+
+function readUint16(view: DataView, offset: number): number {
+  return view.getUint16(offset, false); // big-endian
+}
+
+function readUint32(view: DataView, offset: number): number {
+  return view.getUint32(offset, false);
+}
+
+// GeoJP2 UUID: b14bf8bd-083d-4b43-a5ae-8cd7d5a6ce03
+const GEOJP2_UUID = [0xb1,0x4b,0xf8,0xbd,0x08,0x3d,0x4b,0x43,0xa5,0xae,0x8c,0xd7,0xd5,0xa6,0xce,0x03];
+
+interface PendingBox {
+  type: 'uuid' | 'xml';
+  fileOffset: number;
+  length: number;
+}
+
+interface JP2Boxes {
+  jp2cOffset: number;
+  geoInfo?: GeoInfo;
+  pendingGeoBoxes: PendingBox[];
+}
+
+/** Recursively scan JP2 boxes, including inside asoc superboxes. */
+function scanJP2Boxes(data: Uint8Array, dataFileOffset = 0): JP2Boxes {
+  let jp2cOffset = -1;
+  let geoInfo: GeoInfo | undefined;
+  const pendingGeoBoxes: PendingBox[] = [];
+
+  function scan(start: number, end: number) {
+    const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+    let offset = start;
+    while (offset + 8 <= end) {
+      let boxLen = readUint32(view, offset);
+      const boxType = readUint32(view, offset + 4);
+      let headerSize = 8;
+
+      if (boxLen === 1 && offset + 16 <= end) {
+        boxLen = Number(view.getBigUint64(offset + 8, false));
+        headerSize = 16;
+      }
+      // boxLen === 0 means "box extends to end of file" per ISO 15444-1
+      if (boxLen === 0) {
+        boxLen = end - offset;
+      }
+      if (boxLen < headerSize) break;
+      const boxEnd = offset + boxLen;
+      const clampedEnd = Math.min(boxEnd, end);
+
+      // jp2c = 0x6A703263
+      if (boxType === 0x6A703263) {
+        jp2cOffset = offset + headerSize;
+      }
+
+      // uuid = 0x75756964
+      if (boxType === 0x75756964) {
+        if (offset + headerSize + 16 <= end) {
+          const uuidMatch = GEOJP2_UUID.every((b, i) => data[offset + headerSize + i] === b);
+          if (uuidMatch) {
+            const tiffStart = offset + headerSize + 16;
+            if (boxEnd > end) {
+              // Box content truncated — mark as pending
+              pendingGeoBoxes.push({ type: 'uuid', fileOffset: dataFileOffset + offset, length: boxLen });
+            } else if (clampedEnd > tiffStart) {
+              geoInfo = geoInfo || parseGeoTIFF(data.subarray(tiffStart, clampedEnd));
+            }
+          }
+        } else if (boxLen > headerSize + 16) {
+          // Can't even read UUID bytes — pending
+          pendingGeoBoxes.push({ type: 'uuid', fileOffset: dataFileOffset + offset, length: boxLen });
+        }
+      }
+
+      // xml = 0x786D6C20 (GMLJP2)
+      if (boxType === 0x786D6C20 && !geoInfo) {
+        const xmlStart = offset + headerSize;
+        if (boxEnd > end) {
+          // Truncated XML box
+          pendingGeoBoxes.push({ type: 'xml', fileOffset: dataFileOffset + offset, length: boxLen });
+        } else if (clampedEnd > xmlStart) {
+          const xmlStr = new TextDecoder().decode(data.subarray(xmlStart, clampedEnd));
+          geoInfo = parseGMLJP2(xmlStr);
+        }
+      }
+
+      // asoc = 0x61736F63 — recurse into superbox
+      if (boxType === 0x61736F63) {
+        scan(offset + headerSize, clampedEnd);
+      }
+
+      // Use boxLen (not clampedEnd) to jump to next box even if content was truncated
+      offset += boxLen;
+    }
+  }
+
+  scan(0, data.length);
+  if (jp2cOffset < 0) throw new Error('jp2c box not found');
+  return { jp2cOffset, geoInfo, pendingGeoBoxes };
+}
+
+/** Parse GeoTIFF IFD from GeoJP2 UUID payload. */
+function parseGeoTIFF(data: Uint8Array): GeoInfo | undefined {
+  if (data.length < 8) return undefined;
+  const le = data[0] === 0x49 && data[1] === 0x49; // 'II' = little-endian
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+
+  const r16 = (o: number) => view.getUint16(o, le);
+  const r32 = (o: number) => view.getUint32(o, le);
+  const rF64 = (o: number) => view.getFloat64(o, le);
+
+  const magic = r16(2);
+  if (magic !== 42) return undefined;
+
+  const ifdOffset = r32(4);
+  if (ifdOffset + 2 > data.length) return undefined;
+  const count = r16(ifdOffset);
+
+  let pixelScale: number[] | undefined;
+  let tiepoint: number[] | undefined;
+  let geoKeys: number[] | undefined;
+
+  for (let i = 0; i < count; i++) {
+    const entryOff = ifdOffset + 2 + i * 12;
+    if (entryOff + 12 > data.length) break;
+
+    const tag = r16(entryOff);
+    const type = r16(entryOff + 2);
+    const cnt = r32(entryOff + 4);
+    const valOff = r32(entryOff + 8);
+
+    if (tag === 33550 && type === 12) { // ModelPixelScaleTag, DOUBLE
+      const off = cnt * 8 > 4 ? valOff : entryOff + 8;
+      if (off + cnt * 8 <= data.length) {
+        pixelScale = [];
+        for (let j = 0; j < cnt; j++) pixelScale.push(rF64(off + j * 8));
+      }
+    }
+
+    if (tag === 33922 && type === 12) { // ModelTiepointTag, DOUBLE
+      const off = cnt * 8 > 4 ? valOff : entryOff + 8;
+      if (off + cnt * 8 <= data.length) {
+        tiepoint = [];
+        for (let j = 0; j < cnt; j++) tiepoint.push(rF64(off + j * 8));
+      }
+    }
+
+    if (tag === 34735 && type === 3) { // GeoKeyDirectoryTag, SHORT
+      const off = cnt * 2 > 4 ? valOff : entryOff + 8;
+      if (off + cnt * 2 <= data.length) {
+        geoKeys = [];
+        for (let j = 0; j < cnt; j++) geoKeys.push(r16(off + j * 2));
+      }
+    }
+  }
+
+  if (!pixelScale || !tiepoint || pixelScale.length < 2 || tiepoint.length < 6) return undefined;
+
+  // Extract EPSG from GeoKeys
+  let epsgCode = 0;
+  if (geoKeys && geoKeys.length >= 4) {
+    const numKeys = geoKeys[3];
+    for (let k = 0; k < numKeys; k++) {
+      const base = 4 + k * 4;
+      if (base + 3 >= geoKeys.length) break;
+      const keyId = geoKeys[base];
+      const tiffTagLoc = geoKeys[base + 1];
+      // const count = geoKeys[base + 2];
+      const value = geoKeys[base + 3];
+      // ProjectedCSTypeGeoKey=3072, GeographicTypeGeoKey=2048
+      if ((keyId === 3072 || keyId === 2048) && tiffTagLoc === 0 && value > 0) {
+        epsgCode = value;
+      }
+    }
+  }
+
+  if (epsgCode === 0) {
+    console.warn('GeoJP2: could not determine EPSG code from GeoKeys');
+    return undefined;
+  }
+
+  // Tiepoint: [I, J, K, X, Y, Z] — pixel (I,J) maps to CRS (X,Y)
+  const originX = tiepoint[3] - tiepoint[0] * pixelScale[0];
+  const originY = tiepoint[4] + tiepoint[1] * pixelScale[1];
+
+  console.log(`GeoJP2: EPSG:${epsgCode}, origin=(${originX}, ${originY}), scale=(${pixelScale[0]}, ${pixelScale[1]})`);
+
+  return {
+    originX,
+    originY,
+    pixelScaleX: pixelScale[0],
+    pixelScaleY: pixelScale[1],
+    epsgCode,
+  };
+}
+
+/** Parse GMLJP2 XML for geo info. */
+function parseGMLJP2(xml: string): GeoInfo | undefined {
+  try {
+    // Extract srsName
+    const srsMatch = xml.match(/srsName\s*=\s*["']([^"']+)["']/);
+    if (!srsMatch) return undefined;
+    const srs = srsMatch[1];
+    const epsgMatch = srs.match(/(?:EPSG[:/]+)(\d+)/i);
+    if (!epsgMatch) return undefined;
+    const epsgCode = parseInt(epsgMatch[1], 10);
+
+    // Try RectifiedGrid origin + offsetVector
+    const originMatch = xml.match(/<gml:pos[^>]*>\s*([\d.eE+-]+)\s+([\d.eE+-]+)/);
+    const offsetMatches = [...xml.matchAll(/<gml:offsetVector[^>]*>\s*([\d.eE+-]+)\s+([\d.eE+-]+)/g)];
+
+    if (originMatch && offsetMatches.length >= 2) {
+      const ox = parseFloat(originMatch[1]);
+      const oy = parseFloat(originMatch[2]);
+      // offsetVector[0] = row direction, offsetVector[1] = col direction typically
+      const v0x = parseFloat(offsetMatches[0][1]);
+      const v0y = parseFloat(offsetMatches[0][2]);
+      const v1x = parseFloat(offsetMatches[1][1]);
+      const v1y = parseFloat(offsetMatches[1][2]);
+      const pixelScaleX = Math.abs(v1x) || Math.abs(v0x);
+      const pixelScaleY = Math.abs(v0y) || Math.abs(v1y);
+
+      if (pixelScaleX > 0 && pixelScaleY > 0) {
+        console.log(`GMLJP2: EPSG:${epsgCode}, origin=(${ox}, ${oy}), scale=(${pixelScaleX}, ${pixelScaleY})`);
+        return { originX: ox, originY: oy, pixelScaleX, pixelScaleY, epsgCode };
+      }
+    }
+
+    // Try Envelope lowerCorner/upperCorner (need image dimensions later)
+    const lowerMatch = xml.match(/<gml:lowerCorner[^>]*>\s*([\d.eE+-]+)\s+([\d.eE+-]+)/);
+    const upperMatch = xml.match(/<gml:upperCorner[^>]*>\s*([\d.eE+-]+)\s+([\d.eE+-]+)/);
+    if (lowerMatch && upperMatch) {
+      // Store envelope — pixelScale will be computed later with image dimensions
+      console.log(`GMLJP2: EPSG:${epsgCode}, envelope found (pixelScale needs image dimensions)`);
+      // For now, return with placeholder scales — caller should compute
+      return {
+        originX: parseFloat(lowerMatch[2]),
+        originY: parseFloat(upperMatch[1]),
+        pixelScaleX: 0, // placeholder
+        pixelScaleY: 0,
+        epsgCode,
+      };
+    }
+  } catch {
+    // non-fatal
+  }
+  return undefined;
+}
+
+/** Parse SIZ marker from codestream to extract image/tile dimensions. */
+function parseSIZ(data: Uint8Array, csOffset: number): {
+  width: number; height: number;
+  tileWidth: number; tileHeight: number;
+  componentCount: number;
+  sizEnd: number; // offset after SIZ marker segment
+} {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  // codestream starts with SOC (0xFF4F) then SIZ (0xFF51)
+  let pos = csOffset;
+  const soc = readUint16(view, pos);
+  if (soc !== 0xFF4F) throw new Error(`Expected SOC marker, got 0x${soc.toString(16)}`);
+  pos += 2;
+
+  const sizMarker = readUint16(view, pos);
+  if (sizMarker !== 0xFF51) throw new Error(`Expected SIZ marker, got 0x${sizMarker.toString(16)}`);
+  pos += 2;
+
+  const lsiz = readUint16(view, pos);
+  pos += 2;
+
+  // Skip Rsiz (2 bytes)
+  pos += 2;
+
+  const xsiz = readUint32(view, pos); pos += 4;
+  const ysiz = readUint32(view, pos); pos += 4;
+  const xOsiz = readUint32(view, pos); pos += 4;
+  const yOsiz = readUint32(view, pos); pos += 4;
+  const xtSiz = readUint32(view, pos); pos += 4;
+  const ytSiz = readUint32(view, pos); pos += 4;
+  // Skip XTOsiz, YTOsiz (8 bytes)
+  pos += 8;
+  const csiz = readUint16(view, pos);
+
+  const width = xsiz - xOsiz;
+  const height = ysiz - yOsiz;
+
+  // sizEnd = start of SIZ marker + 2 (marker) + lsiz
+  const sizEnd = csOffset + 2 + 2 + lsiz;
+
+  return {
+    width, height,
+    tileWidth: xtSiz, tileHeight: ytSiz,
+    componentCount: csiz,
+    sizEnd,
+  };
+}
+
+/**
+ * Build the main header bytes: everything from SOC up to (not including) the first SOT marker.
+ * We scan from the SIZ end looking for SOT (0xFF90).
+ */
+function findFirstSOT(data: Uint8Array, afterSIZ: number, csOffset: number): number {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  let pos = afterSIZ;
+  while (pos + 2 <= data.length) {
+    const marker = readUint16(view, pos);
+    if (marker === 0xFF90) {
+      return pos; // SOT found
+    }
+    if ((marker & 0xFF00) !== 0xFF00) {
+      throw new Error(`Invalid marker 0x${marker.toString(16)} at offset ${pos}`);
+    }
+    // Skip marker segment: marker(2) + Lxx(2) + Lxx-2 bytes
+    if (pos + 4 > data.length) break;
+    const segLen = readUint16(view, pos + 2);
+    pos += 2 + segLen;
+  }
+  throw new Error('SOT marker not found in initial data');
+}
+
+/**
+ * Parse JP2 file via HTTP Range requests and build tile index.
+ */
+export async function parseJP2(url: string): Promise<JP2Info> {
+  // Step 1: Read initial chunk to find jp2c, geo info, and parse SIZ
+  const initialSize = 262144; // 256KB to capture geo metadata boxes
+  const initialData = new Uint8Array(await fetchRange(url, 0, initialSize - 1));
+  const { jp2cOffset, geoInfo: initialGeoInfo, pendingGeoBoxes } = scanJP2Boxes(initialData);
+
+  // If geo info not found but there are truncated geo boxes, fetch and parse them
+  let geoInfo = initialGeoInfo;
+  if (!geoInfo && pendingGeoBoxes.length > 0) {
+    for (const pending of pendingGeoBoxes) {
+      try {
+        const boxData = new Uint8Array(await fetchRange(url, pending.fileOffset, pending.fileOffset + pending.length - 1));
+        const view = new DataView(boxData.buffer, boxData.byteOffset, boxData.byteLength);
+        let headerSize = 8;
+        const boxLen = readUint32(view, 0);
+        if (boxLen === 1) headerSize = 16;
+
+        if (pending.type === 'uuid') {
+          const tiffStart = headerSize + 16;
+          if (boxData.length > tiffStart) {
+            geoInfo = parseGeoTIFF(boxData.subarray(tiffStart));
+          }
+        } else {
+          const xmlStr = new TextDecoder().decode(boxData.subarray(headerSize));
+          geoInfo = parseGMLJP2(xmlStr);
+        }
+        if (geoInfo) break;
+      } catch (e) {
+        console.warn(`Failed to fetch pending geo box at offset ${pending.fileOffset}:`, e);
+      }
+    }
+  }
+
+  const siz = parseSIZ(initialData, jp2cOffset);
+  const firstSOTOffset = findFirstSOT(initialData, siz.sizEnd, jp2cOffset);
+
+  // Main header = from codestream start to first SOT
+  const mainHeader = initialData.slice(jp2cOffset, firstSOTOffset);
+
+  const tilesX = Math.ceil(siz.width / siz.tileWidth);
+  const tilesY = Math.ceil(siz.height / siz.tileHeight);
+  const totalTiles = tilesX * tilesY;
+
+  console.log(`JP2 info: ${siz.width}x${siz.height}, tiles ${tilesX}x${tilesY} (${totalTiles}), tile size ${siz.tileWidth}x${siz.tileHeight}`);
+
+  // Step 2: Sequential SOT scan to build tile index
+  const tiles: TileIndex[] = [];
+  let sotOffset = firstSOTOffset; // absolute file offset of current SOT
+
+  for (let i = 0; i < totalTiles; i++) {
+    // Read 12 bytes of SOT marker segment
+    const sotData = new Uint8Array(await fetchRange(url, sotOffset, sotOffset + 11));
+    const view = new DataView(sotData.buffer);
+
+    const marker = readUint16(view, 0);
+    if (marker !== 0xFF90) {
+      throw new Error(`Expected SOT marker at offset ${sotOffset}, got 0x${marker.toString(16)}`);
+    }
+
+    const lsot = readUint16(view, 2); // should be 10
+    const isot = readUint16(view, 4); // tile index
+    const psot = readUint32(view, 6); // tile-part length (includes SOT)
+
+    if (psot === 0) {
+      throw new Error(`Psot=0 (last tile extends to EOC) not supported for tile ${isot}`);
+    }
+
+    tiles.push({
+      tileId: isot,
+      offset: sotOffset,
+      length: psot,
+    });
+
+    // Next SOT is at current offset + psot
+    sotOffset += psot;
+
+    if ((i + 1) % 50 === 0) {
+      console.log(`Indexed ${i + 1}/${totalTiles} tiles...`);
+    }
+  }
+
+  console.log(`Tile index complete: ${tiles.length} tiles indexed`);
+
+  // If GMLJP2 envelope had placeholder pixelScale, compute from image dimensions
+  let finalGeoInfo = geoInfo;
+  if (finalGeoInfo && finalGeoInfo.pixelScaleX === 0) {
+    // We had envelope only — need to compute from dimensions
+    // This is a best-effort fallback
+    finalGeoInfo = undefined;
+  }
+
+  return {
+    width: siz.width,
+    height: siz.height,
+    tileWidth: siz.tileWidth,
+    tileHeight: siz.tileHeight,
+    tilesX,
+    tilesY,
+    componentCount: siz.componentCount,
+    mainHeader,
+    tiles,
+    geoInfo: finalGeoInfo,
+  };
+}
+
+/**
+ * Fetch tile data for a specific tile by its index entry.
+ */
+export async function fetchTileData(url: string, tile: TileIndex): Promise<Uint8Array> {
+  const data = await fetchRange(url, tile.offset, tile.offset + tile.length - 1);
+  return new Uint8Array(data);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,74 @@
+import Map from 'ol/Map';
+import View from 'ol/View';
+import TileLayer from 'ol/layer/Tile';
+import OSM from 'ol/source/OSM';
+import { fromLonLat, transformExtent } from 'ol/proj';
+import { register } from 'ol/proj/proj4';
+import proj4 from 'proj4';
+import { RangeTileProvider } from './range-tile-provider';
+import { createJP2TileLayer } from './source';
+import { createDebugPanel } from './debug-panel';
+import 'ol/ol.css';
+
+// Register common Korean CRS definitions
+proj4.defs('EPSG:5174', '+proj=tmerc +lat_0=38 +lon_0=127.0028902777778 +k=1 +x_0=200000 +y_0=500000 +ellps=bessel +units=m +no_defs +towgs84=-115.80,474.99,674.11,1.16,-2.31,-1.63,6.43');
+proj4.defs('EPSG:5179', '+proj=tmerc +lat_0=38 +lon_0=127.5 +k=0.9996 +x_0=1000000 +y_0=2000000 +ellps=GRS80 +units=m +no_defs');
+proj4.defs('EPSG:5181', '+proj=tmerc +lat_0=38 +lon_0=127 +k=1 +x_0=200000 +y_0=500000 +ellps=GRS80 +units=m +no_defs');
+proj4.defs('EPSG:5186', '+proj=tmerc +lat_0=38 +lon_0=127 +k=1 +x_0=200000 +y_0=600000 +ellps=GRS80 +units=m +no_defs');
+proj4.defs('EPSG:32631', '+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs');
+proj4.defs('EPSG:32652', '+proj=utm +zone=52 +datum=WGS84 +units=m +no_defs');
+register(proj4);
+
+async function main() {
+  const jp2Url = '/sample.jp2';
+
+  console.log('Initializing JP2 tile-based viewer...');
+  const provider = new RangeTileProvider(jp2Url);
+  const { layer: jp2Layer, info, projection, extent, resolutions } = await createJP2TileLayer(provider);
+  console.log(`JP2 ready: ${info.width}x${info.height}, maxDecodeLevel=${info.maxDecodeLevel}`);
+
+  if (info.geoInfo) {
+    console.log(`Geo: EPSG:${info.geoInfo.epsgCode}, extent=[${extent}]`);
+  }
+
+  const maxZoom = Math.log2(info.tileWidth / 256);
+
+  // OSM base layer (always in EPSG:3857)
+  const osmLayer = new TileLayer({ source: new OSM() });
+
+  const hasGeo = !!info.geoInfo;
+
+  if (hasGeo) {
+    // Geographic mode: OSM base + JP2 overlay, map in EPSG:3857
+    const map = new Map({
+      target: 'map',
+      layers: [osmLayer, jp2Layer],
+      view: new View({
+        center: fromLonLat([127.0, 37.5]),
+        zoom: 5,
+      }),
+    });
+    // fit after map renders so it has valid size
+    const mapExtent = transformExtent(extent, projection, 'EPSG:3857');
+    setTimeout(() => {
+      map.getView().fit(mapExtent, { padding: [50, 50, 50, 50] });
+    }, 0);
+    createDebugPanel(map, info);
+  } else {
+    // Pixel mode: no base map
+    const map = new Map({
+      target: 'map',
+      layers: [jp2Layer],
+      view: new View({
+        projection,
+        center: [info.width / 2, info.height / 2],
+        zoom: 0,
+        maxZoom,
+        extent,
+      }),
+    });
+    createDebugPanel(map, info);
+  }
+}
+
+main().catch((err) => console.error('Failed to initialize JP2 viewer:', err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,8 @@ proj4.defs('EPSG:32652', '+proj=utm +zone=52 +datum=WGS84 +units=m +no_defs');
 register(proj4);
 
 async function main() {
-  const jp2Url = '/sample.jp2';
+  const params = new URLSearchParams(window.location.search);
+  const jp2Url = params.get('jp2') || '/sample.jp2';
 
   console.log('Initializing JP2 tile-based viewer...');
   const provider = new RangeTileProvider(jp2Url);

--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { decodedBufferToRGBA, computeMinMax } from './pixel-conversion';
+
+describe('decodedBufferToRGBA', () => {
+  it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
+    const src = new Uint8Array([255,0,0, 0,255,0, 0,0,255, 255,255,255]);
+    const rgba = decodedBufferToRGBA(src.buffer, 2, 2, 3);
+    expect(rgba).toEqual(new Uint8ClampedArray([
+      255,0,0,255,  0,255,0,255,  0,0,255,255,  255,255,255,255,
+    ]));
+  });
+
+  it('8-bit, 1ch: grayscale to RGBA', () => {
+    const src = new Uint8Array([0, 128, 255, 64]);
+    const rgba = decodedBufferToRGBA(src.buffer, 2, 2, 1);
+    expect(rgba).toEqual(new Uint8ClampedArray([
+      0,0,0,255,  128,128,128,255,  255,255,255,255,  64,64,64,255,
+    ]));
+  });
+
+  it('8-bit, 4ch: RGBA passthrough', () => {
+    const src = new Uint8Array([10,20,30,40, 50,60,70,80, 90,100,110,120, 130,140,150,160]);
+    const rgba = decodedBufferToRGBA(src.buffer, 2, 2, 4);
+    expect(rgba).toEqual(new Uint8ClampedArray(src));
+  });
+
+  it('16-bit, 1ch with global min/max: proper normalization', () => {
+    // values: 100, 200, 300, 400 with global range 100-400
+    const src = new Uint16Array([100, 200, 300, 400]);
+    const rgba = decodedBufferToRGBA(src.buffer, 2, 2, 1, 16, 100, 400);
+    // (v - 100) * 255 / 300 | 0
+    expect(rgba[0]).toBe(0);   // (100-100)*255/300 = 0
+    expect(rgba[4]).toBe(85);  // (200-100)*255/300 = 85
+    expect(rgba[8]).toBe(170); // (300-100)*255/300 = 170
+    expect(rgba[12]).toBe(255); // (400-100)*255/300 = 255
+    expect(rgba[3]).toBe(255);
+    // R=G=B for grayscale
+    expect(rgba[0]).toBe(rgba[1]);
+    expect(rgba[0]).toBe(rgba[2]);
+  });
+
+  it('16-bit, 3ch with global min/max: RGB normalization', () => {
+    const src = new Uint16Array([
+      100, 200, 300,
+      400, 100, 200,
+      300, 400, 100,
+      200, 300, 400,
+    ]);
+    const rgba = decodedBufferToRGBA(src.buffer, 2, 2, 3, 16, 100, 400);
+    // range=300
+    expect(rgba[0]).toBe(0);    // (100-100)*255/300
+    expect(rgba[1]).toBe(85);   // (200-100)*255/300
+    expect(rgba[2]).toBe(170);  // (300-100)*255/300
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('16-bit, uniform values with global range: consistent mapping', () => {
+    const src = new Uint16Array([500, 500, 500, 500]);
+    const rgba = decodedBufferToRGBA(src.buffer, 2, 2, 1, 16, 0, 1000);
+    // (500-0)*255/1000 = 127
+    const expected = (500 * 255 / 1000) | 0;
+    expect(rgba[0]).toBe(expected);
+    expect(rgba[4]).toBe(expected);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('16-bit without min/max: falls back to full bit-depth range', () => {
+    const src = new Uint16Array([0, 32767, 65535, 0]);
+    const rgba = decodedBufferToRGBA(src.buffer, 2, 2, 1, 16);
+    // maxVal=65535, min=0 → (v * 255 / 65535) | 0
+    expect(rgba[0]).toBe(0);
+    expect(rgba[4]).toBe(127);
+    expect(rgba[8]).toBe(255);
+  });
+
+  it('16-bit fallback: no bitsPerSample uses byteLength heuristic', () => {
+    const src16 = new Uint16Array([32768]);
+    const rgba16 = decodedBufferToRGBA(src16.buffer, 1, 1, 1);
+    // fallback: maxVal=65535, (32768*255/65535)|0 = 127
+    expect(rgba16[0]).toBe(127);
+
+    const src8 = new Uint8Array([200]);
+    const rgba8 = decodedBufferToRGBA(src8.buffer, 1, 1, 1);
+    expect(rgba8[0]).toBe(200);
+  });
+
+  it('16-bit from WASM-like Uint8Array view: correct reinterpretation', () => {
+    // Simulate WASM heap: a larger ArrayBuffer with our data at an offset
+    const u16data = new Uint16Array([100, 200, 300, 400]);
+    const heap = new ArrayBuffer(1024);
+    const offset = 128;
+    new Uint8Array(heap).set(new Uint8Array(u16data.buffer), offset);
+    const wasmView = new Uint8Array(heap, offset, u16data.byteLength);
+
+    const rgba = decodedBufferToRGBA(wasmView, 2, 2, 1, 16, 100, 400);
+    expect(rgba[0]).toBe(0);   // (100-100)*255/300
+    expect(rgba[4]).toBe(85);  // (200-100)*255/300
+    expect(rgba[8]).toBe(170); // (300-100)*255/300
+    expect(rgba[12]).toBe(255); // (400-100)*255/300
+  });
+});
+
+describe('computeMinMax', () => {
+  it('returns min/max for 16-bit data', () => {
+    const src = new Uint16Array([100, 500, 200, 1000]);
+    const result = computeMinMax(src.buffer, 4, 1, 16);
+    expect(result).toEqual({ min: 100, max: 1000 });
+  });
+
+  it('returns min/max from WASM-like Uint8Array view', () => {
+    const u16data = new Uint16Array([100, 500, 200, 1000]);
+    const heap = new ArrayBuffer(1024);
+    const offset = 64;
+    new Uint8Array(heap).set(new Uint8Array(u16data.buffer), offset);
+    const wasmView = new Uint8Array(heap, offset, u16data.byteLength);
+    const result = computeMinMax(wasmView, 4, 1, 16);
+    expect(result).toEqual({ min: 100, max: 1000 });
+  });
+
+  it('returns null for 8-bit data', () => {
+    const src = new Uint8Array([100, 200]);
+    const result = computeMinMax(src.buffer, 2, 1, 8);
+    expect(result).toBeNull();
+  });
+});

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1,0 +1,114 @@
+/**
+ * Converts a decoded JPEG2000 buffer (8-bit or 16-bit) into RGBA pixel data.
+ */
+/**
+ * Safely create a typed array view from a buffer that may be an ArrayBuffer
+ * or a Uint8Array view (e.g. from WASM heap).
+ */
+function toUint16Array(buf: ArrayBuffer | Uint8Array): Uint16Array {
+  if (buf instanceof ArrayBuffer) {
+    return new Uint16Array(buf);
+  }
+  // Uint8Array view (e.g. WASM heap) — reinterpret bytes as 16-bit
+  return new Uint16Array(buf.buffer, buf.byteOffset, buf.byteLength / 2);
+}
+
+function getByteLength(buf: ArrayBuffer | Uint8Array): number {
+  return buf instanceof ArrayBuffer ? buf.byteLength : buf.byteLength;
+}
+
+export function decodedBufferToRGBA(
+  decodedBuffer: ArrayBuffer | Uint8Array,
+  width: number,
+  height: number,
+  componentCount: number,
+  bitsPerSample?: number,
+  minValue?: number,
+  maxValue?: number,
+): Uint8ClampedArray {
+  const pixelCount = width * height;
+  const expectedBytes8 = pixelCount * componentCount;
+  const bufByteLength = getByteLength(decodedBuffer);
+  const is16bit = bitsPerSample != null ? bitsPerSample > 8 : bufByteLength >= expectedBytes8 * 2;
+  const rgba = new Uint8ClampedArray(pixelCount * 4);
+
+  if (is16bit) {
+    const src = toUint16Array(decodedBuffer);
+
+    // Use provided min/max range, or fall back to full bit-depth range
+    const min = minValue ?? 0;
+    const max = maxValue ?? ((bitsPerSample != null ? (1 << bitsPerSample) - 1 : 65535));
+    const range = max - min || 1;
+
+    if (componentCount === 3) {
+      for (let i = 0; i < pixelCount; i++) {
+        rgba[i * 4]     = ((src[i * 3]     - min) * 255 / range) | 0;
+        rgba[i * 4 + 1] = ((src[i * 3 + 1] - min) * 255 / range) | 0;
+        rgba[i * 4 + 2] = ((src[i * 3 + 2] - min) * 255 / range) | 0;
+        rgba[i * 4 + 3] = 255;
+      }
+    } else if (componentCount === 1) {
+      for (let i = 0; i < pixelCount; i++) {
+        const v = ((src[i] - min) * 255 / range) | 0;
+        rgba[i * 4] = rgba[i * 4 + 1] = rgba[i * 4 + 2] = v;
+        rgba[i * 4 + 3] = 255;
+      }
+    } else if (componentCount === 4) {
+      for (let i = 0; i < pixelCount; i++) {
+        rgba[i * 4]     = ((src[i * 4]     - min) * 255 / range) | 0;
+        rgba[i * 4 + 1] = ((src[i * 4 + 1] - min) * 255 / range) | 0;
+        rgba[i * 4 + 2] = ((src[i * 4 + 2] - min) * 255 / range) | 0;
+        rgba[i * 4 + 3] = ((src[i * 4 + 3] - min) * 255 / range) | 0;
+      }
+    }
+  } else {
+    const src = decodedBuffer instanceof ArrayBuffer
+      ? new Uint8Array(decodedBuffer)
+      : decodedBuffer;
+    if (componentCount === 3) {
+      for (let i = 0; i < pixelCount; i++) {
+        rgba[i * 4]     = src[i * 3];
+        rgba[i * 4 + 1] = src[i * 3 + 1];
+        rgba[i * 4 + 2] = src[i * 3 + 2];
+        rgba[i * 4 + 3] = 255;
+      }
+    } else if (componentCount === 1) {
+      for (let i = 0; i < pixelCount; i++) {
+        rgba[i * 4] = rgba[i * 4 + 1] = rgba[i * 4 + 2] = src[i];
+        rgba[i * 4 + 3] = 255;
+      }
+    } else if (componentCount === 4) {
+      for (let i = 0; i < pixelCount; i++) {
+        rgba[i * 4]     = src[i * 4];
+        rgba[i * 4 + 1] = src[i * 4 + 1];
+        rgba[i * 4 + 2] = src[i * 4 + 2];
+        rgba[i * 4 + 3] = src[i * 4 + 3];
+      }
+    }
+  }
+
+  return rgba;
+}
+
+/**
+ * Computes min/max values from a decoded 16-bit buffer.
+ */
+export function computeMinMax(
+  decodedBuffer: ArrayBuffer | Uint8Array,
+  pixelCount: number,
+  componentCount: number,
+  bitsPerSample?: number,
+): { min: number; max: number } | null {
+  const expectedBytes8 = pixelCount * componentCount;
+  const bufByteLength = getByteLength(decodedBuffer);
+  const is16bit = bitsPerSample != null ? bitsPerSample > 8 : bufByteLength >= expectedBytes8 * 2;
+  if (!is16bit) return null;
+
+  const src = toUint16Array(decodedBuffer);
+  let min = src[0], max = src[0];
+  for (let i = 1; i < src.length; i++) {
+    if (src[i] < min) min = src[i];
+    if (src[i] > max) max = src[i];
+  }
+  return { min, max };
+}

--- a/src/range-tile-provider.ts
+++ b/src/range-tile-provider.ts
@@ -1,0 +1,279 @@
+import type { TileProvider, TileProviderInfo, DecodedTile, GeoInfo } from './tile-provider';
+import { parseJP2, fetchTileData, type JP2Info, type TileIndex } from './jp2-parser';
+import { WorkerPool } from './worker-pool';
+
+const IDB_NAME = 'jp2-tile-index';
+const IDB_VERSION = 1;
+const IDB_STORE = 'indices';
+
+interface CachedIndex {
+  url: string;
+  tiles: TileIndex[];
+  mainHeader: number[];
+  width: number;
+  height: number;
+  tileWidth: number;
+  tileHeight: number;
+  tilesX: number;
+  tilesY: number;
+  componentCount: number;
+  geoInfo?: GeoInfo;
+}
+
+function openIDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_NAME, IDB_VERSION);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(IDB_STORE, { keyPath: 'url' });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function getCachedIndex(url: string): Promise<CachedIndex | undefined> {
+  try {
+    const db = await openIDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, 'readonly');
+      const req = tx.objectStore(IDB_STORE).get(url);
+      req.onsuccess = () => resolve(req.result ?? undefined);
+      req.onerror = () => reject(req.error);
+      tx.oncomplete = () => db.close();
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+async function setCachedIndex(data: CachedIndex): Promise<void> {
+  try {
+    const db = await openIDB();
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, 'readwrite');
+      tx.objectStore(IDB_STORE).put(data);
+      tx.oncomplete = () => { db.close(); resolve(); };
+      tx.onerror = () => { db.close(); reject(tx.error); };
+    });
+  } catch {
+    // caching failure is non-fatal
+  }
+}
+
+// LRU cache for decoded JP2 tiles
+class DecodedTileCache {
+  private map = new Map<string, DecodedTile>();
+  private keys: string[] = [];
+  constructor(private maxSize: number) {}
+
+  get(key: string): DecodedTile | undefined {
+    const val = this.map.get(key);
+    if (val) {
+      // Move to end (most recently used)
+      this.keys.splice(this.keys.indexOf(key), 1);
+      this.keys.push(key);
+    }
+    return val;
+  }
+
+  set(key: string, value: DecodedTile) {
+    if (this.map.has(key)) {
+      this.keys.splice(this.keys.indexOf(key), 1);
+    } else if (this.keys.length >= this.maxSize) {
+      const evict = this.keys.shift()!;
+      this.map.delete(evict);
+    }
+    this.keys.push(key);
+    this.map.set(key, value);
+  }
+}
+
+export class RangeTileProvider implements TileProvider {
+  private info!: JP2Info;
+  private pool = new WorkerPool();
+  private maxDecodeLevel = 5;
+  private cache = new DecodedTileCache(50);
+  private inflight = new Map<string, Promise<DecodedTile>>();
+  private globalMin?: number;
+  private globalMax?: number;
+
+  constructor(private url: string) {}
+
+  async init(): Promise<TileProviderInfo> {
+    this.pool.init();
+
+    const cached = await getCachedIndex(this.url);
+    if (cached) {
+      console.log('Loaded tile index from IndexedDB cache');
+      this.info = {
+        width: cached.width,
+        height: cached.height,
+        tileWidth: cached.tileWidth,
+        tileHeight: cached.tileHeight,
+        tilesX: cached.tilesX,
+        tilesY: cached.tilesY,
+        componentCount: cached.componentCount,
+        mainHeader: new Uint8Array(cached.mainHeader),
+        tiles: cached.tiles,
+        geoInfo: cached.geoInfo,
+      };
+    } else {
+      console.log('Parsing JP2 structure and building tile index...');
+      this.info = await parseJP2(this.url);
+      await setCachedIndex({
+        url: this.url,
+        tiles: this.info.tiles,
+        mainHeader: Array.from(this.info.mainHeader),
+        width: this.info.width,
+        height: this.info.height,
+        tileWidth: this.info.tileWidth,
+        tileHeight: this.info.tileHeight,
+        tilesX: this.info.tilesX,
+        tilesY: this.info.tilesY,
+        componentCount: this.info.componentCount,
+        geoInfo: this.info.geoInfo,
+      });
+      console.log('Tile index cached to IndexedDB');
+    }
+
+    const maxDim = Math.max(this.info.tileWidth, this.info.tileHeight);
+    this.maxDecodeLevel = Math.floor(Math.log2(maxDim / 64));
+    if (this.maxDecodeLevel < 0) this.maxDecodeLevel = 0;
+
+    // Compute global min/max from a sample tile for proper 16-bit normalization
+    await this._computeGlobalStats();
+
+    return {
+      width: this.info.width,
+      height: this.info.height,
+      tileWidth: this.info.tileWidth,
+      tileHeight: this.info.tileHeight,
+      tilesX: this.info.tilesX,
+      tilesY: this.info.tilesY,
+      componentCount: this.info.componentCount,
+      maxDecodeLevel: this.maxDecodeLevel,
+      geoInfo: this.info.geoInfo,
+    };
+  }
+
+  async getTile(col: number, row: number, decodeLevel: number): Promise<DecodedTile> {
+    const cacheKey = `${col}:${row}:${decodeLevel}`;
+
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
+    // Deduplicate concurrent requests for the same tile
+    const existing = this.inflight.get(cacheKey);
+    if (existing) return existing;
+
+    const promise = this._decodeTile(col, row, decodeLevel);
+    this.inflight.set(cacheKey, promise);
+    try {
+      const result = await promise;
+      this.cache.set(cacheKey, result);
+      return result;
+    } finally {
+      this.inflight.delete(cacheKey);
+    }
+  }
+
+  private async _computeGlobalStats(): Promise<void> {
+    try {
+      // Pick a center tile for representative statistics
+      const centerCol = Math.floor(this.info.tilesX / 2);
+      const centerRow = Math.floor(this.info.tilesY / 2);
+      const tileId = centerRow * this.info.tilesX + centerCol;
+      const tileIndex = this.info.tiles.find(t => t.tileId === tileId) ?? this.info.tiles[0];
+      if (!tileIndex) return;
+
+      const { tileWidth, tileHeight, width: imgW, height: imgH, mainHeader } = this.info;
+      const col = tileIndex.tileId % this.info.tilesX;
+      const row = Math.floor(tileIndex.tileId / this.info.tilesX);
+
+      const tileData = await fetchTileData(this.url, tileIndex);
+      const actualW = Math.min(tileWidth, imgW - col * tileWidth);
+      const actualH = Math.min(tileHeight, imgH - row * tileHeight);
+
+      const header = new Uint8Array(mainHeader);
+      const hv = new DataView(header.buffer, header.byteOffset, header.byteLength);
+      const xsizOff = 8;
+      hv.setUint32(xsizOff, actualW, false);
+      hv.setUint32(xsizOff + 4, actualH, false);
+      hv.setUint32(xsizOff + 8, 0, false);
+      hv.setUint32(xsizOff + 12, 0, false);
+      hv.setUint32(xsizOff + 16, actualW, false);
+      hv.setUint32(xsizOff + 20, actualH, false);
+      hv.setUint32(xsizOff + 24, 0, false);
+      hv.setUint32(xsizOff + 28, 0, false);
+
+      const tile = new Uint8Array(tileData);
+      const tv = new DataView(tile.buffer, tile.byteOffset, tile.byteLength);
+      tv.setUint16(4, 0, false);
+
+      const eoc = new Uint8Array([0xFF, 0xD9]);
+      const codestream = new Uint8Array(header.length + tile.length + 2);
+      codestream.set(header, 0);
+      codestream.set(tile, header.length);
+      codestream.set(eoc, header.length + tile.length);
+
+      // Decode at highest reduction level for speed
+      const statsLevel = Math.max(this.maxDecodeLevel, 2);
+      const resp = await this.pool.computeStats(codestream.buffer, statsLevel > 0 ? statsLevel : undefined);
+      if (resp.stats) {
+        this.globalMin = resp.stats.min;
+        this.globalMax = resp.stats.max;
+        console.log(`Global stats from sample tile: min=${this.globalMin}, max=${this.globalMax}`);
+      }
+    } catch (err) {
+      console.warn('Failed to compute global stats, using full-range fallback:', err);
+    }
+  }
+
+  private async _decodeTile(col: number, row: number, decodeLevel: number): Promise<DecodedTile> {
+    const { tilesX, tileWidth, tileHeight, width: imgW, height: imgH, mainHeader } = this.info;
+    const tileId = row * tilesX + col;
+    const tileIndex = this.info.tiles.find(t => t.tileId === tileId);
+    if (!tileIndex) throw new Error(`Tile ${tileId} not found`);
+
+    const tileData = await fetchTileData(this.url, tileIndex);
+
+    const actualW = Math.min(tileWidth, imgW - col * tileWidth);
+    const actualH = Math.min(tileHeight, imgH - row * tileHeight);
+
+    const header = new Uint8Array(mainHeader);
+    const hv = new DataView(header.buffer, header.byteOffset, header.byteLength);
+    const xsizOff = 8;
+    hv.setUint32(xsizOff, actualW, false);
+    hv.setUint32(xsizOff + 4, actualH, false);
+    hv.setUint32(xsizOff + 8, 0, false);
+    hv.setUint32(xsizOff + 12, 0, false);
+    hv.setUint32(xsizOff + 16, actualW, false);
+    hv.setUint32(xsizOff + 20, actualH, false);
+    hv.setUint32(xsizOff + 24, 0, false);
+    hv.setUint32(xsizOff + 28, 0, false);
+
+    const tile = new Uint8Array(tileData);
+    const tv = new DataView(tile.buffer, tile.byteOffset, tile.byteLength);
+    tv.setUint16(4, 0, false);
+
+    const eoc = new Uint8Array([0xFF, 0xD9]);
+    const codestream = new Uint8Array(header.length + tile.length + 2);
+    codestream.set(header, 0);
+    codestream.set(tile, header.length);
+    codestream.set(eoc, header.length + tile.length);
+
+    const resp = await this.pool.decode(codestream.buffer, decodeLevel > 0 ? decodeLevel : undefined, this.globalMin, this.globalMax);
+    if (resp.error) throw new Error(resp.error);
+
+    console.log(`Tile (${col},${row}) decoded: ${resp.width}x${resp.height} (decodeLevel=${decodeLevel})`);
+    return {
+      data: new Uint8ClampedArray(resp.data!),
+      width: resp.width!,
+      height: resp.height!,
+    };
+  }
+
+  destroy() {
+    this.pool.destroy();
+  }
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -2,9 +2,27 @@ import TileImage from 'ol/source/TileImage';
 import TileLayer from 'ol/layer/Tile';
 import TileGrid from 'ol/tilegrid/TileGrid';
 import { Projection, get as getProjection } from 'ol/proj';
+import { register } from 'ol/proj/proj4';
+import proj4 from 'proj4';
 import type Tile from 'ol/Tile';
 import ImageTile from 'ol/ImageTile';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
+
+async function ensureProjection(epsgCode: number): Promise<void> {
+  const code = `EPSG:${epsgCode}`;
+  if (getProjection(code)) return;
+  try {
+    const resp = await fetch(`https://epsg.io/${epsgCode}.proj4`);
+    const def = await resp.text();
+    if (def.trim().startsWith('+')) {
+      proj4.defs(code, def.trim());
+      register(proj4);
+      console.log(`Registered projection ${code} from epsg.io`);
+    }
+  } catch (e) {
+    console.warn(`Failed to fetch projection ${code} from epsg.io:`, e);
+  }
+}
 
 // Semaphore to limit concurrent tile loads
 class Semaphore {
@@ -59,15 +77,33 @@ export async function createJP2TileLayer(
   let projection: Projection;
 
   if (geoInfo) {
+    await ensureProjection(geoInfo.epsgCode);
+
+    // For geographic CRS (e.g. EPSG:4326), origin may have lat/lon order.
+    // OpenLayers expects X=lon, Y=lat. Detect and swap if needed.
+    let { originX, originY, pixelScaleX, pixelScaleY } = geoInfo;
+    const proj = getProjection(`EPSG:${geoInfo.epsgCode}`);
+    const isGeographic = proj ? proj.getUnits() === 'degrees' : geoInfo.epsgCode === 4326;
+    if (isGeographic) {
+      const computedMaxX = originX + width * pixelScaleX;
+      const computedMinY = originY - height * pixelScaleY;
+      // If Y values are out of latitude range but X values look like latitude, swap
+      if ((Math.abs(originY) > 90 || Math.abs(computedMinY) > 90) && Math.abs(originX) <= 90) {
+        console.log('Detected lat/lon axis swap in geo info, correcting...');
+        [originX, originY] = [originY, originX];
+        [pixelScaleX, pixelScaleY] = [pixelScaleY, pixelScaleX];
+      }
+    }
+
     // Geographic mode: compute extent and resolutions in CRS units
-    const minX = geoInfo.originX;
-    const maxY = geoInfo.originY;
-    const maxX = minX + width * geoInfo.pixelScaleX;
-    const minY = maxY - height * geoInfo.pixelScaleY;
+    const minX = originX;
+    const maxY = originY;
+    const maxX = minX + width * pixelScaleX;
+    const minY = maxY - height * pixelScaleY;
     extent = [minX, minY, maxX, maxY];
 
     // Resolutions in CRS units per pixel
-    resolutions = pixelResolutions.map(r => r * geoInfo.pixelScaleX);
+    resolutions = pixelResolutions.map(r => r * pixelScaleX);
 
     const existing = getProjection(`EPSG:${geoInfo.epsgCode}`);
     if (existing) {

--- a/src/source.ts
+++ b/src/source.ts
@@ -1,65 +1,198 @@
 import TileImage from 'ol/source/TileImage';
-import { JP2Decoder } from './decoder';
-import TileState from 'ol/TileState';
+import TileLayer from 'ol/layer/Tile';
+import TileGrid from 'ol/tilegrid/TileGrid';
+import { Projection, get as getProjection } from 'ol/proj';
+import type Tile from 'ol/Tile';
+import ImageTile from 'ol/ImageTile';
+import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 
-export interface JP2SourceOptions {
-  url: string;
-  decoder?: JP2Decoder;
-  tileGrid?: any; // Allow custom tile grid
-}
+// Semaphore to limit concurrent tile loads
+class Semaphore {
+  private queue: Array<() => void> = [];
+  private active = 0;
+  constructor(private max: number) {}
 
-export class JP2Source extends TileImage {
-  private decoder: JP2Decoder;
-  private jp2Url: string;
-
-  constructor(options: JP2SourceOptions) {
-    super({
-      state: 'loading',
-      tileGrid: options.tileGrid,
-      wrapX: false
-    });
-
-    this.jp2Url = options.url;
-    this.decoder = options.decoder || new JP2Decoder();
-    
-    this.setTileLoadFunction(this.jp2TileLoadFunction.bind(this));
-    this.initialize();
+  async acquire(): Promise<void> {
+    if (this.active < this.max) {
+      this.active++;
+      return;
+    }
+    return new Promise(resolve => this.queue.push(resolve));
   }
 
-  private async initialize() {
-    await this.decoder.init();
-    this.setState('ready');
-  }
-
-  private async jp2TileLoadFunction(tile: any, src: string) {
-    const coord = tile.getTileCoord();
-    const z = coord[0];
-    const x = coord[1];
-    const y = coord[2];
-
-    try {
-      // In a real implementation, we would fetch the bitstream
-      // and decode only the requested tile region.
-      // For now, we simulate decoding from the source URL.
-      const response = await fetch(this.jp2Url);
-      if (!response.ok) throw new Error('Failed to fetch JP2');
-      
-      const arrayBuffer = await response.arrayBuffer();
-      const rgbaData = await this.decoder.decode(arrayBuffer);
-
-      // Create a canvas to hold the decoded tile data
-      const canvas = document.createElement('canvas');
-      canvas.width = 256; // Default tile size
-      canvas.height = 256;
-      const ctx = canvas.getContext('2d');
-      if (ctx) {
-        const imageData = new ImageData(rgbaData, 256, 256);
-        ctx.putImageData(imageData, 0, 0);
-        tile.setImage(canvas);
-      }
-    } catch (error) {
-      console.error('JP2 Tile Load Error:', error);
-      tile.setState(TileState.ERROR);
+  release() {
+    this.active--;
+    const next = this.queue.shift();
+    if (next) {
+      this.active++;
+      next();
     }
   }
+}
+
+const DISPLAY_TILE_SIZE = 256;
+
+export interface JP2LayerResult {
+  layer: TileLayer<TileImage>;
+  info: TileProviderInfo;
+  projection: Projection;
+  extent: [number, number, number, number];
+  resolutions: number[];
+}
+
+export async function createJP2TileLayer(
+  provider: TileProvider,
+): Promise<JP2LayerResult> {
+  const info = await provider.init();
+  const { width, height, tileWidth, tileHeight, tilesX, tilesY, geoInfo } = info;
+
+  // Compute resolutions in pixel space
+  const maxRes = tileWidth / DISPLAY_TILE_SIZE;
+  const numLevels = Math.log2(maxRes) + 1;
+  const pixelResolutions: number[] = [];
+  for (let i = 0; i < numLevels; i++) {
+    pixelResolutions.push(maxRes / Math.pow(2, i));
+  }
+
+  let extent: [number, number, number, number];
+  let resolutions: number[];
+  let projection: Projection;
+
+  if (geoInfo) {
+    // Geographic mode: compute extent and resolutions in CRS units
+    const minX = geoInfo.originX;
+    const maxY = geoInfo.originY;
+    const maxX = minX + width * geoInfo.pixelScaleX;
+    const minY = maxY - height * geoInfo.pixelScaleY;
+    extent = [minX, minY, maxX, maxY];
+
+    // Resolutions in CRS units per pixel
+    resolutions = pixelResolutions.map(r => r * geoInfo.pixelScaleX);
+
+    const existing = getProjection(`EPSG:${geoInfo.epsgCode}`);
+    if (existing) {
+      projection = existing as Projection;
+    } else {
+      projection = new Projection({
+        code: `EPSG:${geoInfo.epsgCode}`,
+        units: 'm',
+        extent,
+      });
+    }
+  } else {
+    // Pixel mode (no geo info)
+    extent = [0, 0, width, height];
+    resolutions = pixelResolutions;
+    projection = new Projection({
+      code: 'jp2-image',
+      units: 'pixels',
+      extent,
+    });
+  }
+
+  const origin: [number, number] = geoInfo
+    ? [extent[0], extent[3]] // top-left in CRS
+    : [0, height];
+
+  const tileGrid = new TileGrid({
+    extent,
+    origin,
+    resolutions,
+    tileSize: [DISPLAY_TILE_SIZE, DISPLAY_TILE_SIZE],
+  });
+
+  const sem = new Semaphore(4);
+
+  const source = new TileImage({
+    projection,
+    tileGrid,
+    tileUrlFunction: (tileCoord) => {
+      const [z, x, y] = tileCoord;
+      const subtilesPerAxis = tileWidth / DISPLAY_TILE_SIZE / pixelResolutions[z];
+
+      const jp2Col = Math.floor(x / subtilesPerAxis);
+      const jp2Row = Math.floor(y / subtilesPerAxis);
+      const subCol = x % subtilesPerAxis;
+      const subRow = y % subtilesPerAxis;
+
+      if (jp2Row < 0 || jp2Row >= tilesY || jp2Col < 0 || jp2Col >= tilesX) {
+        return undefined;
+      }
+
+      const decodeLevel = Math.round(Math.log2(pixelResolutions[z]));
+
+      return `jp2:#col=${jp2Col}&row=${jp2Row}&dl=${decodeLevel}&sc=${subCol}&sr=${subRow}`;
+    },
+    tileLoadFunction: (tile: Tile, src: string) => {
+      const match = src.match(/col=(\d+)&row=(\d+)&dl=(\d+)&sc=(\d+)&sr=(\d+)/);
+      if (!match) {
+        tile.setState(3);
+        return;
+      }
+
+      const col = parseInt(match[1], 10);
+      const row = parseInt(match[2], 10);
+      const decodeLevel = parseInt(match[3], 10);
+      const subCol = parseInt(match[4], 10);
+      const subRow = parseInt(match[5], 10);
+
+      const imageTile = tile as ImageTile;
+      const img = imageTile.getImage() as HTMLImageElement;
+
+      (async () => {
+        await sem.acquire();
+        try {
+          const decoded = await provider.getTile(col, row, decodeLevel);
+
+          const canvas = document.createElement('canvas');
+          canvas.width = DISPLAY_TILE_SIZE;
+          canvas.height = DISPLAY_TILE_SIZE;
+          const ctx = canvas.getContext('2d')!;
+
+          const sx = subCol * DISPLAY_TILE_SIZE;
+          const sy = subRow * DISPLAY_TILE_SIZE;
+          const sw = Math.min(DISPLAY_TILE_SIZE, decoded.width - sx);
+          const sh = Math.min(DISPLAY_TILE_SIZE, decoded.height - sy);
+
+          if (sw > 0 && sh > 0) {
+            const fullImage = new ImageData(
+              new Uint8ClampedArray(decoded.data.buffer as ArrayBuffer),
+              decoded.width,
+              decoded.height,
+            );
+
+            const subData = ctx.createImageData(sw, sh);
+            for (let r = 0; r < sh; r++) {
+              const srcOffset = ((sy + r) * decoded.width + sx) * 4;
+              const dstOffset = r * sw * 4;
+              subData.data.set(
+                fullImage.data.subarray(srcOffset, srcOffset + sw * 4),
+                dstOffset,
+              );
+            }
+            ctx.putImageData(subData, 0, 0);
+          }
+
+          canvas.toBlob((blob) => {
+            if (blob) {
+              const url = URL.createObjectURL(blob);
+              img.onload = () => URL.revokeObjectURL(url);
+              img.src = url;
+            }
+          });
+        } catch (err) {
+          console.error(`Failed to load tile (${col},${row}) sub(${subCol},${subRow}):`, err);
+          tile.setState(3);
+        } finally {
+          sem.release();
+        }
+      })();
+    },
+  });
+
+  const layer = geoInfo
+    ? new TileLayer({ source })
+    : new TileLayer({ source, extent });
+
+  return { layer, info, projection, extent, resolutions };
 }

--- a/src/tile-provider.ts
+++ b/src/tile-provider.ts
@@ -1,0 +1,31 @@
+export interface DecodedTile {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+export interface GeoInfo {
+  originX: number;
+  originY: number;
+  pixelScaleX: number;
+  pixelScaleY: number;
+  epsgCode: number;
+}
+
+export interface TileProviderInfo {
+  width: number;
+  height: number;
+  tileWidth: number;
+  tileHeight: number;
+  tilesX: number;
+  tilesY: number;
+  componentCount: number;
+  maxDecodeLevel: number;
+  geoInfo?: GeoInfo;
+}
+
+export interface TileProvider {
+  init(): Promise<TileProviderInfo>;
+  getTile(col: number, row: number, decodeLevel: number): Promise<DecodedTile>;
+  destroy(): void;
+}

--- a/src/worker-pool.ts
+++ b/src/worker-pool.ts
@@ -1,0 +1,75 @@
+import type { DecodeRequest, DecodeResponse } from './decode-worker';
+
+interface PendingTask {
+  resolve: (resp: DecodeResponse) => void;
+  reject: (err: Error) => void;
+}
+
+export class WorkerPool {
+  private workers: Worker[] = [];
+  private queue: Array<{ request: DecodeRequest; resolve: (r: DecodeResponse) => void; reject: (e: Error) => void }> = [];
+  private busy = new Set<Worker>();
+  private pending = new Map<number, PendingTask>();
+  private nextId = 0;
+
+  constructor(private size: number = Math.min(navigator.hardwareConcurrency || 4, 4)) {}
+
+  init() {
+    for (let i = 0; i < this.size; i++) {
+      const worker = new Worker(new URL('./decode-worker.ts', import.meta.url), { type: 'module' });
+      worker.onmessage = (e: MessageEvent<DecodeResponse>) => {
+        const resp = e.data;
+        const task = this.pending.get(resp.id);
+        if (task) {
+          this.pending.delete(resp.id);
+          task.resolve(resp);
+        }
+        this.busy.delete(worker);
+        this.dispatch();
+      };
+      worker.onerror = (e) => {
+        console.error('Worker error:', e);
+        this.busy.delete(worker);
+        this.dispatch();
+      };
+      this.workers.push(worker);
+    }
+  }
+
+  decode(codestream: ArrayBuffer, decodeLevel?: number, minValue?: number, maxValue?: number): Promise<DecodeResponse> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      const request: DecodeRequest = { id, codestream, decodeLevel, minValue, maxValue };
+      this.queue.push({ request, resolve, reject });
+      this.dispatch();
+    });
+  }
+
+  computeStats(codestream: ArrayBuffer, decodeLevel?: number): Promise<DecodeResponse> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      const request: DecodeRequest = { id, codestream, decodeLevel, statsOnly: true };
+      this.queue.push({ request, resolve, reject });
+      this.dispatch();
+    });
+  }
+
+  private dispatch() {
+    while (this.queue.length > 0) {
+      const idle = this.workers.find(w => !this.busy.has(w));
+      if (!idle) break;
+      const task = this.queue.shift()!;
+      this.busy.add(idle);
+      this.pending.set(task.request.id, { resolve: task.resolve, reject: task.reject });
+      idle.postMessage(task.request, [task.request.codestream]);
+    }
+  }
+
+  destroy() {
+    for (const w of this.workers) w.terminate();
+    this.workers = [];
+    this.queue = [];
+    this.pending.clear();
+    this.busy.clear();
+  }
+}

--- a/test-tile-loading.mjs
+++ b/test-tile-loading.mjs
@@ -1,0 +1,86 @@
+import { chromium } from 'playwright';
+
+const BASE_URL = 'http://localhost:5177';
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  // Collect network requests
+  const rangeRequests = [];
+  page.on('request', (req) => {
+    const range = req.headers()['range'];
+    if (range) {
+      rangeRequests.push({ url: req.url(), range });
+    }
+  });
+
+  const consoleMessages = [];
+  page.on('console', (msg) => {
+    consoleMessages.push(msg.text());
+  });
+
+  const errors = [];
+  page.on('pageerror', (err) => {
+    errors.push(err.message);
+  });
+
+  console.log('Navigating to', BASE_URL);
+  await page.goto(BASE_URL, { waitUntil: 'load', timeout: 60000 });
+
+  // Wait for tile indexing + some tile decoding
+  await page.waitForTimeout(30000);
+
+  console.log('\n=== Console Messages ===');
+  for (const msg of consoleMessages) {
+    console.log(' ', msg);
+  }
+
+  console.log('\n=== Range Requests ===');
+  console.log(`  Total Range requests: ${rangeRequests.length}`);
+  if (rangeRequests.length > 0) {
+    // Show first 5 and last 5
+    const show = rangeRequests.slice(0, 5);
+    for (const r of show) {
+      console.log(`  ${r.range}`);
+    }
+    if (rangeRequests.length > 5) {
+      console.log(`  ... (${rangeRequests.length - 5} more)`);
+    }
+  }
+
+  console.log('\n=== Errors ===');
+  if (errors.length === 0) {
+    console.log('  No errors!');
+  } else {
+    for (const e of errors) {
+      console.log(' ', e);
+    }
+  }
+
+  // Check if canvas tiles were rendered
+  const tileCount = await page.evaluate(() => {
+    const canvases = document.querySelectorAll('canvas');
+    return canvases.length;
+  });
+  console.log(`\n=== Render ===`);
+  console.log(`  Canvas elements: ${tileCount}`);
+
+  // Check JP2 info was parsed
+  const hasJP2Info = consoleMessages.some((m) => m.includes('JP2 info:'));
+  const hasTileIndex = consoleMessages.some((m) => m.includes('Tile index complete'));
+  const hasTileLoad = consoleMessages.some((m) => m.includes('decoded'));
+
+  console.log(`\n=== Summary ===`);
+  console.log(`  JP2 parsed:      ${hasJP2Info ? 'YES' : 'NO'}`);
+  console.log(`  Index built:     ${hasTileIndex ? 'YES' : 'NO'}`);
+  console.log(`  Tiles loaded:    ${hasTileLoad ? 'YES' : 'NO'}`);
+  console.log(`  Range requests:  ${rangeRequests.length > 0 ? 'YES' : 'NO'}`);
+  console.log(`  Errors:          ${errors.length === 0 ? 'NONE' : errors.length}`);
+
+  const passed = hasJP2Info && hasTileIndex && hasTileLoad && rangeRequests.length > 0 && errors.length === 0;
+  console.log(`\n  Result: ${passed ? 'PASS ✓' : 'FAIL ✗'}`);
+
+  await browser.close();
+  process.exit(passed ? 0 : 1);
+})();

--- a/tests/osm-jp2.spec.ts
+++ b/tests/osm-jp2.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('OSM + JP2 overlay', () => {
+  test('page loads with map canvas', async ({ page }) => {
+    await page.goto('/');
+    const map = page.locator('#map');
+    await expect(map).toBeVisible();
+    // OpenLayers renders canvas inside .ol-viewport
+    const canvas = page.locator('.ol-viewport canvas');
+    await expect(canvas.first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test('OSM tiles load successfully', async ({ page }) => {
+    const osmResponse = page.waitForResponse(
+      (resp) => resp.url().includes('tile.openstreetmap.org') && resp.status() === 200,
+      { timeout: 15000 }
+    );
+    await page.goto('/');
+    await osmResponse;
+  });
+
+  test('canvas has non-empty pixels', async ({ page }) => {
+    await page.goto('/');
+    // Wait for tiles to render
+    await page.waitForTimeout(8000);
+
+    const hasPixels = await page.evaluate(() => {
+      const canvases = document.querySelectorAll('.ol-viewport canvas');
+      for (const c of canvases) {
+        const canvas = c as HTMLCanvasElement;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) continue;
+        const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+        for (let i = 3; i < data.length; i += 4) {
+          if (data[i] > 0) return true;
+        }
+      }
+      return false;
+    });
+
+    expect(hasPixels).toBe(true);
+  });
+
+  test('no unexpected console errors', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        const text = msg.text();
+        // Allow known JP2 init errors (e.g. missing sample file)
+        if (text.includes('Failed to initialize JP2 viewer')) return;
+        errors.push(text);
+      }
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(5000);
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    proxy: {
+      '/proxy/gcs-sentinel2': {
+        target: 'https://storage.googleapis.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/proxy\/gcs-sentinel2/, ''),
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- WASM decoder의 `getDecodedBuffer()`가 반환하는 `Uint8Array` 뷰를 `Uint16Array`로 변환할 때 바이트를 올바르게 재해석하도록 수정
- `new Uint16Array(uint8array)` 대신 `new Uint16Array(buf.buffer, buf.byteOffset, buf.byteLength / 2)` 사용
- WASM heap 뷰를 시뮬레이션하는 테스트 케이스 추가

## Test plan
- [x] `npx vitest run` — 12 tests 통과
- [ ] 브라우저에서 16-bit JP2 영상이 크로스해치 없이 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)