### PR TITLE
fix(worker-pool): reject pending tasks on worker error and destroy

### DIFF
--- a/src/worker-pool.spec.ts
+++ b/src/worker-pool.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock Worker before importing WorkerPool
+class MockWorker {
+  onmessage: ((e: any) => void) | null = null;
+  onerror: ((e: any) => void) | null = null;
+  postMessage = vi.fn();
+  terminate = vi.fn();
+}
+
+vi.stubGlobal('Worker', function (this: MockWorker) {
+  const w = new MockWorker();
+  mockWorkers.push(w);
+  return w;
+} as any);
+
+let mockWorkers: MockWorker[] = [];
+
+// Dynamic import to pick up mocked Worker
+const { WorkerPool } = await import('./worker-pool');
+
+describe('WorkerPool', () => {
+  beforeEach(() => {
+    mockWorkers = [];
+  });
+
+  it('rejects pending task on worker error', async () => {
+    const pool = new WorkerPool(1);
+    pool.init();
+
+    const worker = mockWorkers[0];
+    const buf = new ArrayBuffer(8);
+    const promise = pool.decode(buf);
+
+    // Simulate worker error
+    worker.onerror!({ message: 'crash' } as any);
+
+    await expect(promise).rejects.toThrow('Worker error');
+  });
+
+  it('rejects all tasks on destroy', async () => {
+    const pool = new WorkerPool(1);
+    pool.init();
+
+    const buf1 = new ArrayBuffer(8);
+    const buf2 = new ArrayBuffer(8);
+    const p1 = pool.decode(buf1);
+    const p2 = pool.decode(buf2); // queued (only 1 worker)
+
+    pool.destroy();
+
+    await expect(p1).rejects.toThrow('WorkerPool destroyed');
+    await expect(p2).rejects.toThrow('WorkerPool destroyed');
+  });
+});

--- a/src/worker-pool.ts
+++ b/src/worker-pool.ts
@@ -10,6 +10,7 @@ export class WorkerPool {
   private queue: Array<{ request: DecodeRequest; resolve: (r: DecodeResponse) => void; reject: (e: Error) => void }> = [];
   private busy = new Set<Worker>();
   private pending = new Map<number, PendingTask>();
+  private activeTask = new Map<Worker, number>();
   private nextId = 0;
 
   constructor(private size: number = Math.min(navigator.hardwareConcurrency || 4, 4)) {}
@@ -24,11 +25,21 @@ export class WorkerPool {
           this.pending.delete(resp.id);
           task.resolve(resp);
         }
+        this.activeTask.delete(worker);
         this.busy.delete(worker);
         this.dispatch();
       };
       worker.onerror = (e) => {
         console.error('Worker error:', e);
+        const taskId = this.activeTask.get(worker);
+        if (taskId != null) {
+          const task = this.pending.get(taskId);
+          if (task) {
+            this.pending.delete(taskId);
+            task.reject(new Error(`Worker error: ${e.message || 'unknown error'}`));
+          }
+          this.activeTask.delete(worker);
+        }
         this.busy.delete(worker);
         this.dispatch();
       };
@@ -61,6 +72,7 @@ export class WorkerPool {
       const task = this.queue.shift()!;
       this.busy.add(idle);
       this.pending.set(task.request.id, { resolve: task.resolve, reject: task.reject });
+      this.activeTask.set(idle, task.request.id);
       idle.postMessage(task.request, [task.request.codestream]);
     }
   }
@@ -68,8 +80,15 @@ export class WorkerPool {
   destroy() {
     for (const w of this.workers) w.terminate();
     this.workers = [];
+    for (const task of this.queue) {
+      task.reject(new Error('WorkerPool destroyed'));
+    }
     this.queue = [];
+    for (const task of this.pending.values()) {
+      task.reject(new Error('WorkerPool destroyed'));
+    }
     this.pending.clear();
+    this.activeTask.clear();
     this.busy.clear();
   }
 }


### PR DESCRIPTION
## Summary
- WorkerPool의 `onerror` 핸들러에서 해당 워커가 처리 중이던 pending task를 `reject()`하도록 수정
- `destroy()` 호출 시 큐에 대기 중인 task와 pending task 모두 reject 처리
- 워커별 활성 task ID 추적을 위한 `activeTask` Map 추가

## Test plan
- [x] `worker-pool.spec.ts` 단위 테스트 추가 (onerror reject, destroy reject)
- [x] `npm test` 14 tests 통과

closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)