### PR TITLE
refactor(codestream): extract buildTileCodestream to remove duplication

### DIFF
--- a/src/codestream-builder.spec.ts
+++ b/src/codestream-builder.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildTileCodestream } from './codestream-builder';
+
+describe('buildTileCodestream', () => {
+  it('patches SIZ dimensions, resets tile index, and appends EOC', () => {
+    // Create a minimal 40-byte header (enough for SIZ fields up to offset 36)
+    const header = new Uint8Array(40);
+    // Create a minimal tile part with SOT marker (10 bytes min: FF90 + length + tile index)
+    const tileData = new Uint8Array([0xFF, 0x90, 0x00, 0x0A, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]);
+
+    const result = buildTileCodestream(header, tileData, 256, 128);
+
+    // Check total length: header(40) + tile(10) + EOC(2)
+    expect(result.length).toBe(52);
+
+    const dv = new DataView(result.buffer, result.byteOffset, result.byteLength);
+
+    // SIZ patched dimensions at offset 8
+    expect(dv.getUint32(8, false)).toBe(256);   // Xsiz = actualW
+    expect(dv.getUint32(12, false)).toBe(128);  // Ysiz = actualH
+    expect(dv.getUint32(16, false)).toBe(0);    // XOsiz
+    expect(dv.getUint32(20, false)).toBe(0);    // YOsiz
+    expect(dv.getUint32(24, false)).toBe(256);  // XTsiz
+    expect(dv.getUint32(28, false)).toBe(128);  // YTsiz
+
+    // Tile index reset to 0
+    expect(dv.getUint16(44, false)).toBe(0);
+
+    // EOC marker at end
+    expect(result[50]).toBe(0xFF);
+    expect(result[51]).toBe(0xD9);
+  });
+
+  it('does not mutate the original header or tileData', () => {
+    const header = new Uint8Array(40);
+    header[8] = 0x01;
+    const headerCopy = new Uint8Array(header);
+
+    const tileData = new Uint8Array([0xFF, 0x90, 0x00, 0x0A, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00]);
+    const tileCopy = new Uint8Array(tileData);
+
+    buildTileCodestream(header, tileData, 100, 100);
+
+    // Originals should be unchanged
+    expect(header).toEqual(headerCopy);
+    expect(tileData).toEqual(tileCopy);
+  });
+});

--- a/src/codestream-builder.ts
+++ b/src/codestream-builder.ts
@@ -1,0 +1,36 @@
+/**
+ * Builds a single-tile JP2 codestream by patching the SIZ marker in the
+ * main header, resetting the tile index, and appending EOC.
+ */
+export function buildTileCodestream(
+  mainHeader: Uint8Array,
+  tileData: Uint8Array,
+  actualW: number,
+  actualH: number,
+): Uint8Array {
+  const header = new Uint8Array(mainHeader);
+  const hv = new DataView(header.buffer, header.byteOffset, header.byteLength);
+
+  // SIZ marker is at offset 4 from SOC (0xFF4F); Xsiz starts at byte 8
+  const xsizOff = 8;
+  hv.setUint32(xsizOff, actualW, false);
+  hv.setUint32(xsizOff + 4, actualH, false);
+  hv.setUint32(xsizOff + 8, 0, false);   // XOsiz
+  hv.setUint32(xsizOff + 12, 0, false);  // YOsiz
+  hv.setUint32(xsizOff + 16, actualW, false);  // XTsiz
+  hv.setUint32(xsizOff + 20, actualH, false);  // YTsiz
+  hv.setUint32(xsizOff + 24, 0, false);  // XTOsiz
+  hv.setUint32(xsizOff + 28, 0, false);  // YTOsiz
+
+  const tile = new Uint8Array(tileData);
+  const tv = new DataView(tile.buffer, tile.byteOffset, tile.byteLength);
+  tv.setUint16(4, 0, false); // Reset tile index to 0
+
+  const eoc = new Uint8Array([0xFF, 0xD9]);
+  const codestream = new Uint8Array(header.length + tile.length + 2);
+  codestream.set(header, 0);
+  codestream.set(tile, header.length);
+  codestream.set(eoc, header.length + tile.length);
+
+  return codestream;
+}

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -1,6 +1,7 @@
 import { decode } from '@abasb75/openjpeg';
 import type { DecodedOpenJPEG } from '@abasb75/openjpeg/types';
 import { decodedBufferToRGBA } from './pixel-conversion';
+import { buildTileCodestream } from './codestream-builder';
 
 export interface DecodeResult {
   data: Uint8ClampedArray;
@@ -33,35 +34,11 @@ export class JP2Decoder {
     tileHeight: number,
     imageWidth: number,
     imageHeight: number,
-    tilesX: number,
   ): Promise<DecodeResult> {
     const actualW = Math.min(tileWidth, imageWidth - tileCol * tileWidth);
     const actualH = Math.min(tileHeight, imageHeight - tileRow * tileHeight);
 
-    const header = new Uint8Array(mainHeader);
-    const hv = new DataView(header.buffer, header.byteOffset, header.byteLength);
-
-    const sizOffset = 4;
-    const xsizOff = sizOffset + 4;
-    hv.setUint32(xsizOff, actualW, false);
-    hv.setUint32(xsizOff + 4, actualH, false);
-    hv.setUint32(xsizOff + 8, 0, false);
-    hv.setUint32(xsizOff + 12, 0, false);
-    hv.setUint32(xsizOff + 16, actualW, false);
-    hv.setUint32(xsizOff + 20, actualH, false);
-    hv.setUint32(xsizOff + 24, 0, false);
-    hv.setUint32(xsizOff + 28, 0, false);
-
-    const tile = new Uint8Array(tileData);
-    const tv = new DataView(tile.buffer, tile.byteOffset, tile.byteLength);
-    tv.setUint16(4, 0, false);
-
-    const eoc = new Uint8Array([0xFF, 0xD9]);
-    const codestream = new Uint8Array(header.length + tile.length + 2);
-    codestream.set(header, 0);
-    codestream.set(tile, header.length);
-    codestream.set(eoc, header.length + tile.length);
-
-    return this.decode(codestream.buffer);
+    const codestream = buildTileCodestream(mainHeader, tileData, actualW, actualH);
+    return this.decode(codestream.buffer as ArrayBuffer);
   }
 }

--- a/src/range-tile-provider.ts
+++ b/src/range-tile-provider.ts
@@ -1,6 +1,7 @@
 import type { TileProvider, TileProviderInfo, DecodedTile, GeoInfo } from './tile-provider';
 import { parseJP2, fetchTileData, type JP2Info, type TileIndex } from './jp2-parser';
 import { WorkerPool } from './worker-pool';
+import { buildTileCodestream } from './codestream-builder';
 
 const IDB_NAME = 'jp2-tile-index';
 const IDB_VERSION = 1;
@@ -194,31 +195,11 @@ export class RangeTileProvider implements TileProvider {
       const actualW = Math.min(tileWidth, imgW - col * tileWidth);
       const actualH = Math.min(tileHeight, imgH - row * tileHeight);
 
-      const header = new Uint8Array(mainHeader);
-      const hv = new DataView(header.buffer, header.byteOffset, header.byteLength);
-      const xsizOff = 8;
-      hv.setUint32(xsizOff, actualW, false);
-      hv.setUint32(xsizOff + 4, actualH, false);
-      hv.setUint32(xsizOff + 8, 0, false);
-      hv.setUint32(xsizOff + 12, 0, false);
-      hv.setUint32(xsizOff + 16, actualW, false);
-      hv.setUint32(xsizOff + 20, actualH, false);
-      hv.setUint32(xsizOff + 24, 0, false);
-      hv.setUint32(xsizOff + 28, 0, false);
-
-      const tile = new Uint8Array(tileData);
-      const tv = new DataView(tile.buffer, tile.byteOffset, tile.byteLength);
-      tv.setUint16(4, 0, false);
-
-      const eoc = new Uint8Array([0xFF, 0xD9]);
-      const codestream = new Uint8Array(header.length + tile.length + 2);
-      codestream.set(header, 0);
-      codestream.set(tile, header.length);
-      codestream.set(eoc, header.length + tile.length);
+      const codestream = buildTileCodestream(mainHeader, new Uint8Array(tileData), actualW, actualH);
 
       // Decode at highest reduction level for speed
       const statsLevel = Math.max(this.maxDecodeLevel, 2);
-      const resp = await this.pool.computeStats(codestream.buffer, statsLevel > 0 ? statsLevel : undefined);
+      const resp = await this.pool.computeStats(codestream.buffer as ArrayBuffer, statsLevel > 0 ? statsLevel : undefined);
       if (resp.stats) {
         this.globalMin = resp.stats.min;
         this.globalMax = resp.stats.max;
@@ -240,29 +221,9 @@ export class RangeTileProvider implements TileProvider {
     const actualW = Math.min(tileWidth, imgW - col * tileWidth);
     const actualH = Math.min(tileHeight, imgH - row * tileHeight);
 
-    const header = new Uint8Array(mainHeader);
-    const hv = new DataView(header.buffer, header.byteOffset, header.byteLength);
-    const xsizOff = 8;
-    hv.setUint32(xsizOff, actualW, false);
-    hv.setUint32(xsizOff + 4, actualH, false);
-    hv.setUint32(xsizOff + 8, 0, false);
-    hv.setUint32(xsizOff + 12, 0, false);
-    hv.setUint32(xsizOff + 16, actualW, false);
-    hv.setUint32(xsizOff + 20, actualH, false);
-    hv.setUint32(xsizOff + 24, 0, false);
-    hv.setUint32(xsizOff + 28, 0, false);
+    const codestream = buildTileCodestream(mainHeader, new Uint8Array(tileData), actualW, actualH);
 
-    const tile = new Uint8Array(tileData);
-    const tv = new DataView(tile.buffer, tile.byteOffset, tile.byteLength);
-    tv.setUint16(4, 0, false);
-
-    const eoc = new Uint8Array([0xFF, 0xD9]);
-    const codestream = new Uint8Array(header.length + tile.length + 2);
-    codestream.set(header, 0);
-    codestream.set(tile, header.length);
-    codestream.set(eoc, header.length + tile.length);
-
-    const resp = await this.pool.decode(codestream.buffer, decodeLevel > 0 ? decodeLevel : undefined, this.globalMin, this.globalMax);
+    const resp = await this.pool.decode(codestream.buffer as ArrayBuffer, decodeLevel > 0 ? decodeLevel : undefined, this.globalMin, this.globalMax);
     if (resp.error) throw new Error(resp.error);
 
     console.log(`Tile (${col},${row}) decoded: ${resp.width}x${resp.height} (decodeLevel=${decodeLevel})`);


### PR DESCRIPTION
## Summary
- `buildTileCodestream()` 유틸 함수를 `codestream-builder.ts`에 추출
- `decoder.ts`의 `decodeTile()`과 `range-tile-provider.ts`의 `_decodeTile()`, `_computeGlobalStats()`에서 중복된 SIZ 패치 + EOC 조립 로직 제거
- 미사용 `tilesX` 파라미터 제거 (`decoder.ts`)

## Test plan
- [x] `codestream-builder.spec.ts` 단위 테스트 추가
- [x] `npm test` 14 tests 통과
- [x] 기존 타입 에러 수 변화 없음 (4개 유지)

closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)