### PR TITLE
fix(types): resolve SharedArrayBuffer/ArrayBuffer tsc errors

### DIFF
--- a/src/decode-worker.ts
+++ b/src/decode-worker.ts
@@ -31,15 +31,15 @@ self.onmessage = async (e: MessageEvent<DecodeRequest>) => {
     const { width, height, componentCount, bitsPerSample } = result.frameInfo;
 
     if (statsOnly) {
-      const stats = computeMinMax(result.decodedBuffer, width * height, componentCount, bitsPerSample);
+      const stats = computeMinMax(new Uint8Array(result.decodedBuffer), width * height, componentCount, bitsPerSample);
       const resp: DecodeResponse = { id, width, height, stats: stats ?? undefined };
       (self as unknown as Worker).postMessage(resp);
       return;
     }
 
-    const rgba = decodedBufferToRGBA(result.decodedBuffer, width, height, componentCount, bitsPerSample, minValue, maxValue);
+    const rgba = decodedBufferToRGBA(new Uint8Array(result.decodedBuffer), width, height, componentCount, bitsPerSample, minValue, maxValue);
 
-    const resp: DecodeResponse = { id, data: rgba.buffer, width, height };
+    const resp: DecodeResponse = { id, data: rgba.buffer as ArrayBuffer, width, height };
     (self as unknown as Worker).postMessage(resp, [rgba.buffer]);
   } catch (err: any) {
     const resp: DecodeResponse = { id, error: err?.message ?? String(err) };

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -17,7 +17,7 @@ export class JP2Decoder {
     const result: DecodedOpenJPEG = await decode(data, decodeLevel != null ? { decodeLevel } : undefined);
 
     const { width, height, componentCount, bitsPerSample } = result.frameInfo;
-    const rgba = decodedBufferToRGBA(result.decodedBuffer, width, height, componentCount, bitsPerSample, minValue, maxValue);
+    const rgba = decodedBufferToRGBA(new Uint8Array(result.decodedBuffer), width, height, componentCount, bitsPerSample, minValue, maxValue);
     console.log(`JP2 decoded: ${width}x${height}, ${componentCount}ch, ${bitsPerSample}bps`);
     return { data: rgba, width, height };
   }


### PR DESCRIPTION
## Summary
- `ArrayBufferLike`를 `new Uint8Array()`로 감싸거나 `as ArrayBuffer`로 캐스팅하여 tsc strict 모드 에러 4개 수정
- `npx tsc --noEmit` 에러 0개 확인

closes #10

## Test plan
- [x] `npx tsc --noEmit` 에러 없음
- [x] `npm test` 18개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)