### PR TITLE
docs(sprint-3): update CHANGELOG, README, and JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 3
+
+### Fixed
+- **debug-logger**: `debugError()` 함수 추가 — `console.error`도 `setDebug()`로 제어 (#15, PR #17)
+  - `source.ts`와 `worker-pool.ts`의 `console.error`를 `debugError()`로 교체
+  - 모든 로그/경고/에러 출력이 `setDebug(false)`(기본값)에서 완전히 억제됨
+
+### Added
+- **Public API**: `src/index.ts` 라이브러리 진입점 추가 (#16, PR #18)
+  - `setDebug`, `createJP2TileLayer`, `RangeTileProvider` 및 관련 타입 export
+  - 라이브러리 소비자가 `import { setDebug } from 'openlayers-jp2provider'`로 디버그 모드 제어 가능
+
+---
+
 ## [Unreleased] — Sprint 2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ npx playwright test  # E2E 테스트
 | `src/jp2-parser.ts` | JP2/JPEG2000 파일 파싱 |
 | `src/pixel-conversion.ts` | 픽셀 데이터 변환 유틸리티 |
 | `src/debug-logger.ts` | 조건부 디버그 로거 (`setDebug`로 on/off) |
+| `src/index.ts` | 라이브러리 공개 API 진입점 |
 
 ## API
 
@@ -87,4 +88,19 @@ setDebug(false); // 콘솔 출력 비활성화 (기본값)
 
 - 기본값 `false` — 프로덕션 빌드에서 콘솔 출력 없음
 - `setDebug(true)` 호출 후 라이브러리 내부의 `debugLog`/`debugWarn`이 `[JP2]` 프리픽스와 함께 출력됨
-- 실제 오류(`console.error`)는 항상 출력됨
+- 실제 오류(`console.error`)도 `setDebug(false)`에서 억제됨 (sprint 3부터)
+
+### Public API (`src/index.ts`)
+
+라이브러리로 사용 시 `src/index.ts`를 통해 공개 API를 import합니다.
+
+```typescript
+import { setDebug, createJP2TileLayer, RangeTileProvider } from 'openlayers-jp2provider';
+import type { JP2LayerResult, TileProvider, TileProviderInfo, GeoInfo } from 'openlayers-jp2provider';
+
+// 디버그 로그 활성화
+setDebug(true);
+
+// JP2 레이어 생성
+const { layer, view } = createJP2TileLayer({ url: 'path/to/file.jp2' });
+```

--- a/src/debug-logger.ts
+++ b/src/debug-logger.ts
@@ -24,6 +24,9 @@ export function debugWarn(...args: unknown[]): void {
   if (enabled) console.warn('[JP2]', ...args);
 }
 
+/**
+ * 디버그 모드가 활성화된 경우 `[JP2]` 프리픽스와 함께 `console.error`를 호출한다.
+ */
 export function debugError(...args: unknown[]): void {
   if (enabled) console.error('[JP2]', ...args);
 }


### PR DESCRIPTION
## Summary
- **CHANGELOG.md**: sprint 3 섹션 추가 — `debugError` 추가(#15), public API export(#16)
- **README.md**: `src/index.ts` 모듈 행 추가, Public API 섹션 추가, `setDebug` 설명 수정
- **src/debug-logger.ts**: `debugError()` JSDoc 주석 추가

## Test plan
- [x] `npm test` 29개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)