### PR TITLE
chore(build): configure vite lib mode and package.json entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,18 @@
   "name": "openlayersjp2provider",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
-  "directories": {
-    "doc": "docs"
+  "main": "dist/openlayersjp2provider.mjs",
+  "module": "dist/openlayersjp2provider.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/openlayersjp2provider.mjs",
+      "types": "./dist/index.d.ts"
+    }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'path';
 
 export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      formats: ['es'],
+      fileName: 'openlayersjp2provider',
+    },
+    rollupOptions: {
+      external: (id: string) => id === 'proj4' || id === 'ol' || id.startsWith('ol/'),
+    },
+  },
   server: {
     proxy: {
       '/proxy/gcs-sentinel2': {


### PR DESCRIPTION
## Summary
- vite.config.ts에 lib 모드 설정 추가 (`src/index.ts` entry, ES format)
- ol/* 및 proj4를 external 처리하여 번들에서 제외
- package.json의 main, module, exports, types, files 필드 업데이트

closes #19

## Test plan
- [x] `npm run build` 성공 확인
- [x] `npm test` 29개 테스트 전부 통과
- [x] dist 출력물에 setDebug, createJP2TileLayer, RangeTileProvider export 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)