### PR TITLE
docs(sprint-4): update CHANGELOG and README for build entry changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ public/*.jp2
 sprint-logs/*.log
 sprint-logs/.sprint.lock
 sprint-logs/sprint-tools/
+sprint-logs/
 !sprint-logs/*.handoff.json
 !sprint-logs/sprint-memory.md
 !sprint-logs/*-summary.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 4
+
+### Changed
+- **빌드**: Vite lib 모드 설정 추가 — `src/index.ts`를 진입점으로 ES 포맷 단일 번들 출력 (#19)
+  - `vite.config.ts`에 `build.lib` 설정 추가 (`entry: src/index.ts`, `formats: ['es']`)
+  - `ol/*` 및 `proj4` peer dependency를 external 처리하여 번들에서 제외
+  - `package.json`에 `main`, `module`, `exports`, `types`, `files` 필드 추가
+  - 빌드 출력 파일: `dist/openlayersjp2provider.mjs`, `dist/index.d.ts`
+
+---
+
+## [Unreleased] — Sprint 3
+
+### Fixed
+- **debug-logger**: `debugError()` 함수 추가 — `console.error` 직접 호출을 `debugError`로 교체 (#17)
+
+### Added
+- **Public API**: `setDebug`를 `src/index.ts`에서 공개 API로 export (#18)
+  - `import { setDebug } from 'openlayersjp2provider'`로 외부에서 접근 가능
+
+---
+
 ## [Unreleased] — Sprint 2
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ npx playwright test  # E2E 테스트
 
 | 파일 | 설명 |
 |------|------|
+| `src/index.ts` | 라이브러리 공개 API 진입점 (`createJP2TileLayer`, `RangeTileProvider`, `setDebug` export) |
 | `src/source.ts` | OpenLayers TileSource 생성 |
 | `src/range-tile-provider.ts` | HTTP Range 요청으로 JP2 타일 데이터 조회, IndexedDB 캐시 관리 |
 | `src/codestream-builder.ts` | JP2 단일 타일 codestream 조립 유틸리티 |
@@ -76,15 +77,35 @@ const codestream = buildTileCodestream(mainHeader, tileData, width, height);
 
 SIZ 마커를 패치하고 EOC를 추가하여 단일 타일 JP2 codestream을 조립합니다.
 
-### `setDebug` / `debugLog` / `debugWarn`
+### `createJP2TileLayer`
 
 ```typescript
-import { setDebug } from './debug-logger';
+import { createJP2TileLayer } from 'openlayersjp2provider';
+
+const { layer, info, projection, extent, resolutions } = await createJP2TileLayer(provider);
+```
+
+JP2 파일의 GeoInfo를 읽어 OpenLayers `TileLayer`와 투영 정보를 생성합니다.
+
+### `setDebug`
+
+```typescript
+import { setDebug } from 'openlayersjp2provider';
 
 setDebug(true);  // [JP2] 프리픽스로 콘솔 출력 활성화
 setDebug(false); // 콘솔 출력 비활성화 (기본값)
 ```
 
 - 기본값 `false` — 프로덕션 빌드에서 콘솔 출력 없음
-- `setDebug(true)` 호출 후 라이브러리 내부의 `debugLog`/`debugWarn`이 `[JP2]` 프리픽스와 함께 출력됨
-- 실제 오류(`console.error`)는 항상 출력됨
+- `setDebug(true)` 호출 후 라이브러리 내부의 `debugLog`/`debugWarn`/`debugError`가 `[JP2]` 프리픽스와 함께 출력됨
+
+## 패키징
+
+라이브러리는 ES 모듈 단일 번들로 빌드됩니다.
+
+- 빌드 출력: `dist/openlayersjp2provider.mjs`, `dist/index.d.ts`
+- Peer dependencies (`ol`, `proj4`)는 번들에서 제외됩니다. 사용 환경에서 별도 설치 필요합니다.
+
+```bash
+npm install ol proj4 openlayersjp2provider
+```

--- a/package.json
+++ b/package.json
@@ -2,10 +2,18 @@
   "name": "openlayersjp2provider",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
-  "directories": {
-    "doc": "docs"
+  "main": "dist/openlayersjp2provider.mjs",
+  "module": "dist/openlayersjp2provider.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/openlayersjp2provider.mjs",
+      "types": "./dist/index.d.ts"
+    }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/sprint-logs/sprint-4-6-orchestrator-end.handoff.json
+++ b/sprint-logs/sprint-4-6-orchestrator-end.handoff.json
@@ -1,0 +1,10 @@
+{
+  "role": "orchestrator-end",
+  "sprint": 4,
+  "status": "success",
+  "merged_prs": [21, 20],
+  "closed_issues": [19],
+  "new_issues_created": [],
+  "released": false,
+  "next_action": "Documenter: PR #21(build entry 통일) 및 PR #20(sprint-3 docs) 머지 완료 — CHANGELOG와 README에 빌드 설정 변경사항 반영 필요"
+}

--- a/sprint-logs/sprint-memory.md
+++ b/sprint-logs/sprint-memory.md
@@ -4,7 +4,9 @@
 - IndexedDB 타일 인덱스 캐시: IDB_VERSION 2, TTL + URL 기반 무효화 적용
 - WebWorker 풀: activeTask 맵으로 워커별 pending 작업 추적 (오류 시 reject 보장)
 - buildTileCodestream: range-tile-provider.ts와 decoder.ts 공통 함수로 추출
-- debug-logger.ts: setDebug()/debugLog()/debugWarn() 모듈로 프로덕션 로그 조건화, 기본값 silent
+- debug-logger.ts: setDebug()/debugLog()/debugWarn()/debugError() 모듈로 프로덕션 로그 조건화, 기본값 silent
+- src/index.ts: 라이브러리 public API entry point — setDebug, JP2TileSource 등 export
+- package.json main/module/types 필드와 vite.config.ts lib.entry 모두 src/index.ts로 통일 (PR #21)
 
 ## 반복 패턴 & 주의사항
 - 동일 작성자 PR은 GitHub 정책상 공식 approve 불가 → 리뷰 코멘트로 대체
@@ -12,17 +14,19 @@
 - module-private 함수는 단위 테스트 불가 → 공개 API 경유 검증으로 대체
 - fake-indexeddb를 devDependency로 추가하여 IDB 테스트 환경 구성
 - 선행 PR 머지 후 후행 PR이 충돌 상태가 될 수 있음 → rebase 후 force-with-lease push 필요
+- main.ts는 데모 진입점이므로 console.error 교체 대상에서 제외
 
 ## 기술 부채 목록
 - [x] tsc 타입 에러 4개 잔존 (SharedArrayBuffer/ArrayBuffer 호환성) — PR #12로 해결
+- [x] setDebug()를 라이브러리 public API로 export — PR #18로 해결
+- [x] package.json main 필드와 vite.config.ts lib.entry를 src/index.ts로 업데이트 — PR #21로 해결
 - [ ] decoder.ts의 decodeTile()은 현재 미사용 상태이나 public API로 유지 중
-- [ ] setDebug()를 라이브러리 public API로 export 고려 (현재는 main.ts에서만 호출)
 
 ## 최근 3개 스프린트 요약
-### Sprint 2 (2026-03-09)
-- 완료: PR #12(fix/10), PR #13(refactor/11), PR #9(docs/sprint-1) 머지, 이슈 #10 #11 닫힘
-- 발견된 문제: PR #13이 #12 머지 후 충돌 → rebase로 해결
+### Sprint 4 (2026-03-10)
+- 완료: PR #21(chore/19), PR #20(docs/sprint-3) 머지, 이슈 #19 닫힘
+- 발견된 문제: 없음
 
-### Sprint 1 (2026-03-09)
-- 완료: PR #5(fix/2), PR #6(refactor/3), PR #7(feat/4) 머지, 이슈 #2 #3 #4 닫힘
-- 발견된 문제: tsc 타입 에러 4개 기존 잔존 (스프린트 2에서 해결)
+### Sprint 3 (2026-03-10)
+- 완료: PR #17(fix/15), PR #18(feat/16), PR #14(docs/sprint-2) 머지, 이슈 #15 #16 닫힘
+- 발견된 문제: package.json/vite.config.ts 빌드 설정이 src/index.ts를 가리키지 않음 → 이슈 #19 생성

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vite';
+import { resolve } from 'path';
 
 export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      formats: ['es'],
+      fileName: 'openlayersjp2provider',
+    },
+    rollupOptions: {
+      external: (id: string) => id === 'proj4' || id === 'ol' || id.startsWith('ol/'),
+    },
+  },
   server: {
     proxy: {
       '/proxy/gcs-sentinel2': {


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 3(debugError #17, setDebug export #18) 및 Sprint 4(vite lib mode #19) 섹션 추가
- README에 `src/index.ts` 모듈 행 추가, `createJP2TileLayer` Public API 섹션 추가
- `setDebug` import 경로를 패키지명(`openlayersjp2provider`)으로 수정
- 패키징 섹션 추가 (ES 모듈 번들, peer dependencies 안내)

## Test plan
- [x] `npm test` 29개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)