### PR TITLE
feat(api): export JP2Decoder and DecodeResult from public API

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@abasb75/openjpeg', () => ({ decode: vi.fn() }));
+
 import * as publicApi from './index';
 
 describe('public API (index.ts)', () => {
@@ -12,6 +15,10 @@ describe('public API (index.ts)', () => {
 
   it('RangeTileProvider 클래스를 export한다', () => {
     expect(typeof publicApi.RangeTileProvider).toBe('function');
+  });
+
+  it('JP2Decoder 클래스를 export한다', () => {
+    expect(typeof publicApi.JP2Decoder).toBe('function');
   });
 
   it('setDebug(true/false) 호출이 오류 없이 동작한다', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,5 @@ export { createJP2TileLayer } from './source';
 export type { JP2LayerResult } from './source';
 export type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 export { RangeTileProvider } from './range-tile-provider';
+export { JP2Decoder } from './decoder';
+export type { DecodeResult } from './decoder';


### PR DESCRIPTION
## Summary
- `JP2Decoder` 클래스와 `DecodeResult` 타입을 `src/index.ts`에서 named export
- `src/index.spec.ts`에 JP2Decoder export 확인 테스트 추가

closes #23

## Test plan
- [x] `npm test` 통과 확인
- [ ] `import { JP2Decoder, DecodeResult } from 'openlayers-jp2provider'` 타입 오류 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)