### PR TITLE
docs(sprint-6): update CHANGELOG and README for destroy() and cacheTTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 6
+
+### Added
+- **`JP2LayerResult.destroy()`**: `createJP2TileLayer()`가 반환하는 결과에 `destroy()` 메서드 추가 (closes #28, PR #30)
+  - `destroy()` 호출 시 내부 `TileProvider.destroy()` → `WorkerPool.destroy()` 연쇄 호출로 WebWorker 풀 해제
+- **`RangeTileProvider` `cacheTTL` 옵션**: 생성자 옵션에 `cacheTTL` 추가 (closes #29, PR #30)
+  - `new RangeTileProvider(url, { cacheTTL: ms })` 형태로 IndexedDB 캐시 TTL 커스텀 설정 가능
+  - 기본값은 기존과 동일한 24시간
+
+---
+
+## [Unreleased] — Sprint 5
+
+### Added
+- **`JP2Decoder` public export**: `JP2Decoder` 클래스와 `DecodeResult` 타입을 공개 API로 export (#25, PR #25)
+  - 소비자가 직접 JP2 파일을 디코딩할 수 있도록 `JP2Decoder` 직접 인스턴스화 지원
+- **`JP2LayerOptions`**: `createJP2TileLayer()` 두 번째 인자로 옵션 객체 추가 (#26, PR #26)
+  - `maxConcurrentTiles`: 동시 타일 로드 최대 수 (기본값: 4)
+  - `projectionResolver`: EPSG 코드에 대한 proj4 문자열을 반환하는 커스텀 resolver
+
+---
+
+## [Unreleased] — Sprint 4
+
+### Added
+- **Vite lib mode 빌드**: `vite.config.ts` lib 모드 설정, `package.json` entry points 구성 (#21)
+  - `dist/openlayers-jp2provider.js` (ESM), `dist/openlayers-jp2provider.umd.cjs` (UMD) 번들 생성
+  - `package.json`에 `main`, `module`, `exports` 필드 추가
+
+---
+
 ## [Unreleased] — Sprint 3
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -39,12 +39,54 @@ npx playwright test  # E2E 테스트
 
 ## API
 
+### `createJP2TileLayer`
+
+```typescript
+const result = await createJP2TileLayer(provider, options);
+```
+
+#### 옵션 (`JP2LayerOptions`)
+
+| 옵션 | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `maxConcurrentTiles` | `number` | `4` | 동시 타일 로드 최대 수 |
+| `projectionResolver` | `(epsgCode: number) => Promise<string \| null>` | epsg.io fetch | EPSG 코드에 대한 proj4 문자열 resolver |
+
+#### 반환값 (`JP2LayerResult`)
+
+| 속성 | 타입 | 설명 |
+|------|------|------|
+| `layer` | `TileLayer<TileImage>` | OpenLayers 레이어 |
+| `info` | `TileProviderInfo` | JP2 파일 메타데이터 |
+| `projection` | `Projection` | 좌표계 |
+| `extent` | `[number, number, number, number]` | 범위 |
+| `resolutions` | `number[]` | 해상도 목록 |
+| `destroy` | `() => void` | 내부 리소스(WebWorker 풀) 해제 |
+
+```typescript
+const { layer, projection, extent, destroy } = await createJP2TileLayer(provider);
+
+// 사용 완료 후 리소스 해제
+destroy();
+```
+
 ### `RangeTileProvider`
 
 JP2 파일을 Range 요청으로 분할 조회하는 타일 프로바이더.
 
 ```typescript
 const provider = new RangeTileProvider(url, options);
+```
+
+#### 생성자 옵션
+
+| 옵션 | 타입 | 기본값 | 설명 |
+|------|------|--------|------|
+| `cacheTTL` | `number` | `86400000` (24시간) | IndexedDB 캐시 TTL (밀리초) |
+
+```typescript
+// TTL을 1시간으로 설정
+const provider = new RangeTileProvider(url, { cacheTTL: 60 * 60 * 1000 });
 ```
 
 #### 정적 메서드
@@ -58,6 +100,7 @@ await RangeTileProvider.invalidateCache(url: string): Promise<void>
 
 - JP2 타일 인덱스를 `jp2-tile-index` DB (버전 2)에 저장
 - 기본 TTL: 24시간 (만료 시 자동 삭제 후 재파싱)
+- `cacheTTL` 옵션으로 TTL 커스텀 가능
 - `invalidateCache(url)`로 수동 무효화 가능
 
 ### `WorkerPool`
@@ -95,12 +138,29 @@ setDebug(false); // 콘솔 출력 비활성화 (기본값)
 라이브러리로 사용 시 `src/index.ts`를 통해 공개 API를 import합니다.
 
 ```typescript
-import { setDebug, createJP2TileLayer, RangeTileProvider } from 'openlayers-jp2provider';
-import type { JP2LayerResult, TileProvider, TileProviderInfo, GeoInfo } from 'openlayers-jp2provider';
+import { setDebug, createJP2TileLayer, RangeTileProvider, JP2Decoder } from 'openlayers-jp2provider';
+import type {
+  JP2LayerResult,
+  JP2LayerOptions,
+  TileProvider,
+  TileProviderInfo,
+  GeoInfo,
+  DecodeResult,
+} from 'openlayers-jp2provider';
 
 // 디버그 로그 활성화
 setDebug(true);
 
-// JP2 레이어 생성
-const { layer, view } = createJP2TileLayer({ url: 'path/to/file.jp2' });
+// JP2 레이어 생성 (커스텀 TTL 및 동시 로드 수 설정)
+const provider = new RangeTileProvider('path/to/file.jp2', { cacheTTL: 60 * 60 * 1000 });
+const { layer, projection, extent, destroy } = await createJP2TileLayer(provider, {
+  maxConcurrentTiles: 8,
+});
+
+// 사용 완료 후 리소스 해제
+destroy();
+
+// JP2Decoder 직접 사용
+const decoder = new JP2Decoder();
+const result: DecodeResult = await decoder.decode(jp2Data);
 ```

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -31,4 +31,14 @@ describe('public API (index.ts)', () => {
     // createJP2TileLayer(provider, options?) — 파라미터 2개 선언
     expect(publicApi.createJP2TileLayer.length).toBe(2);
   });
+
+  it('RangeTileProvider가 cacheTTL 옵션을 받는다', () => {
+    const provider = new publicApi.RangeTileProvider('https://example.com/test.jp2', { cacheTTL: 1000 });
+    expect(provider).toBeInstanceOf(publicApi.RangeTileProvider);
+  });
+
+  it('RangeTileProvider에 destroy 메서드가 존재한다', () => {
+    const provider = new publicApi.RangeTileProvider('https://example.com/test.jp2');
+    expect(typeof provider.destroy).toBe('function');
+  });
 });

--- a/src/range-tile-provider.spec.ts
+++ b/src/range-tile-provider.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@abasb75/openjpeg', () => ({ decode: vi.fn() }));
+
+const mockDestroy = vi.hoisted(() => vi.fn());
+const mockInit = vi.hoisted(() => vi.fn());
+
+vi.mock('./worker-pool', () => ({
+  WorkerPool: class {
+    init = mockInit;
+    decode = vi.fn();
+    computeStats = vi.fn();
+    destroy = mockDestroy;
+  },
+}));
+
+const { RangeTileProvider } = await import('./range-tile-provider');
+
+describe('RangeTileProvider', () => {
+  beforeEach(() => {
+    mockDestroy.mockClear();
+    mockInit.mockClear();
+  });
+
+  describe('destroy()', () => {
+    it('내부 WorkerPool.destroy()를 호출한다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2');
+      provider.destroy();
+      expect(mockDestroy).toHaveBeenCalledOnce();
+    });
+
+    it('init() 없이 destroy()를 호출해도 오류가 발생하지 않는다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2');
+      expect(() => provider.destroy()).not.toThrow();
+    });
+
+    it('destroy()를 여러 번 호출해도 오류가 발생하지 않는다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2');
+      provider.destroy();
+      expect(() => provider.destroy()).not.toThrow();
+      expect(mockDestroy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('cacheTTL 옵션', () => {
+    it('cacheTTL 없이 생성하면 정상적으로 초기화된다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2');
+      expect(provider).toBeInstanceOf(RangeTileProvider);
+    });
+
+    it('cacheTTL 커스텀 값으로 생성하면 정상적으로 초기화된다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2', { cacheTTL: 5000 });
+      expect(provider).toBeInstanceOf(RangeTileProvider);
+    });
+
+    it('cacheTTL에 0을 지정해도 오류가 발생하지 않는다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2', { cacheTTL: 0 });
+      expect(provider).toBeInstanceOf(RangeTileProvider);
+    });
+  });
+});

--- a/src/range-tile-provider.ts
+++ b/src/range-tile-provider.ts
@@ -128,12 +128,16 @@ export class RangeTileProvider implements TileProvider {
   private globalMin?: number;
   private globalMax?: number;
 
-  constructor(private url: string) {}
+  private cacheTTL: number;
+
+  constructor(private url: string, options?: { cacheTTL?: number }) {
+    this.cacheTTL = options?.cacheTTL ?? DEFAULT_TTL_MS;
+  }
 
   async init(): Promise<TileProviderInfo> {
     this.pool.init();
 
-    const cached = await getCachedIndex(this.url);
+    const cached = await getCachedIndex(this.url, this.cacheTTL);
     if (cached) {
       debugLog('Loaded tile index from IndexedDB cache');
       this.info = {

--- a/src/source.ts
+++ b/src/source.ts
@@ -72,6 +72,8 @@ export interface JP2LayerResult {
   projection: Projection;
   extent: [number, number, number, number];
   resolutions: number[];
+  /** 내부 리소스(WebWorker 등)를 해제한다 */
+  destroy: () => void;
 }
 
 export async function createJP2TileLayer(
@@ -247,5 +249,9 @@ export async function createJP2TileLayer(
     ? new TileLayer({ source })
     : new TileLayer({ source, extent });
 
-  return { layer, info, projection, extent, resolutions };
+  const destroy = () => {
+    provider.destroy();
+  };
+
+  return { layer, info, projection, extent, resolutions, destroy };
 }

--- a/src/worker-pool.spec.ts
+++ b/src/worker-pool.spec.ts
@@ -52,4 +52,17 @@ describe('WorkerPool', () => {
     await expect(p1).rejects.toThrow('WorkerPool destroyed');
     await expect(p2).rejects.toThrow('WorkerPool destroyed');
   });
+
+  it('destroy 시 모든 Worker의 terminate가 호출된다', () => {
+    const pool = new WorkerPool(3);
+    pool.init();
+
+    expect(mockWorkers).toHaveLength(3);
+
+    pool.destroy();
+
+    for (const w of mockWorkers) {
+      expect(w.terminate).toHaveBeenCalledOnce();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 6 섹션 추가: `JP2LayerResult.destroy()` (#28), `RangeTileProvider cacheTTL` (#29), PR #30
- CHANGELOG에 Sprint 4, 5 누락 섹션 추가 (PR #27 미머지로 누락됐던 내용)
- README: `createJP2TileLayer` 옵션/반환값 테이블 추가 (`JP2LayerOptions`, `JP2LayerResult`)
- README: `RangeTileProvider` 생성자 `cacheTTL` 옵션 문서화
- README: Public API 예제 업데이트 (`destroy()`, `cacheTTL`, `JP2Decoder` 포함)

## Test plan
- [x] `npm test` 40개 테스트 전체 통과
- [x] CHANGELOG 내용이 PR #30 변경사항과 일치 확인
- [x] README 코드 예제 문법 오류 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)