### PR TITLE
feat(api): add minValue/maxValue pixel normalization options

### DIFF
--- a/src/range-tile-provider.spec.ts
+++ b/src/range-tile-provider.spec.ts
@@ -42,6 +42,35 @@ describe('RangeTileProvider', () => {
     });
   });
 
+  describe('minValue/maxValue 옵션', () => {
+    it('minValue/maxValue 없이 생성하면 정상적으로 초기화된다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2');
+      expect(provider).toBeInstanceOf(RangeTileProvider);
+    });
+
+    it('minValue/maxValue 커스텀 값으로 생성하면 정상적으로 초기화된다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2', {
+        minValue: 0,
+        maxValue: 65535,
+      });
+      expect(provider).toBeInstanceOf(RangeTileProvider);
+    });
+
+    it('minValue만 지정해도 오류가 발생하지 않는다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2', {
+        minValue: 100,
+      });
+      expect(provider).toBeInstanceOf(RangeTileProvider);
+    });
+
+    it('maxValue만 지정해도 오류가 발생하지 않는다', () => {
+      const provider = new RangeTileProvider('https://example.com/test.jp2', {
+        maxValue: 50000,
+      });
+      expect(provider).toBeInstanceOf(RangeTileProvider);
+    });
+  });
+
   describe('cacheTTL 옵션', () => {
     it('cacheTTL 없이 생성하면 정상적으로 초기화된다', () => {
       const provider = new RangeTileProvider('https://example.com/test.jp2');

--- a/src/range-tile-provider.ts
+++ b/src/range-tile-provider.ts
@@ -130,8 +130,13 @@ export class RangeTileProvider implements TileProvider {
 
   private cacheTTL: number;
 
-  constructor(private url: string, options?: { cacheTTL?: number }) {
+  private userMin?: number;
+  private userMax?: number;
+
+  constructor(private url: string, options?: { cacheTTL?: number; minValue?: number; maxValue?: number }) {
     this.cacheTTL = options?.cacheTTL ?? DEFAULT_TTL_MS;
+    this.userMin = options?.minValue;
+    this.userMax = options?.maxValue;
   }
 
   async init(): Promise<TileProviderInfo> {
@@ -176,8 +181,14 @@ export class RangeTileProvider implements TileProvider {
     this.maxDecodeLevel = Math.floor(Math.log2(maxDim / 64));
     if (this.maxDecodeLevel < 0) this.maxDecodeLevel = 0;
 
-    // Compute global min/max from a sample tile for proper 16-bit normalization
-    await this._computeGlobalStats();
+    // Use user-provided min/max or compute from a sample tile
+    if (this.userMin !== undefined && this.userMax !== undefined) {
+      this.globalMin = this.userMin;
+      this.globalMax = this.userMax;
+      debugLog(`Using user-provided pixel range: min=${this.globalMin}, max=${this.globalMax}`);
+    } else {
+      await this._computeGlobalStats();
+    }
 
     return {
       width: this.info.width,

--- a/src/source.ts
+++ b/src/source.ts
@@ -64,6 +64,10 @@ export interface JP2LayerOptions {
   maxConcurrentTiles?: number;
   /** EPSG 코드에 대한 proj4 문자열을 반환하는 커스텀 resolver (기본값: epsg.io fetch) */
   projectionResolver?: (epsgCode: number) => Promise<string | null>;
+  /** 픽셀 정규화 최소값 (16비트 이미지용) */
+  minValue?: number;
+  /** 픽셀 정규화 최대값 (16비트 이미지용) */
+  maxValue?: number;
 }
 
 export interface JP2LayerResult {


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `minValue`, `maxValue` 옵션 추가
- `RangeTileProvider` 생성자에서 `minValue`/`maxValue` 옵션 수용, 자동 계산 대신 사용자 지정 값 우선 적용
- 단위 테스트 추가

closes #32

## Test plan
- [x] `npm test` 통과 (44 tests)
- [ ] 16비트 JP2 이미지에서 minValue/maxValue 지정 시 정규화 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)