### PR TITLE
feat(api): add tileRetryCount option for tile load retry

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -68,6 +68,8 @@ export interface JP2LayerOptions {
   minValue?: number;
   /** 픽셀 정규화 최대값 (16비트 이미지용) */
   maxValue?: number;
+  /** 타일 로드 실패 시 재시도 횟수 (기본값: 0, 재시도 없음) */
+  tileRetryCount?: number;
 }
 
 export interface JP2LayerResult {
@@ -161,6 +163,7 @@ export async function createJP2TileLayer(
   });
 
   const sem = new Semaphore(options?.maxConcurrentTiles ?? 4);
+  const retryCount = options?.tileRetryCount ?? 0;
 
   const source = new TileImage({
     projection,
@@ -201,7 +204,24 @@ export async function createJP2TileLayer(
       (async () => {
         await sem.acquire();
         try {
-          const decoded = await provider.getTile(col, row, decodeLevel);
+          let decoded;
+          let lastErr: unknown;
+          for (let attempt = 0; attempt <= retryCount; attempt++) {
+            try {
+              decoded = await provider.getTile(col, row, decodeLevel);
+              break;
+            } catch (err) {
+              lastErr = err;
+              if (attempt < retryCount) {
+                debugWarn(`Tile (${col},${row}) load failed (attempt ${attempt + 1}/${retryCount + 1}), retrying...`);
+              }
+            }
+          }
+          if (!decoded) {
+            debugError(`Failed to load tile (${col},${row}) sub(${subCol},${subRow}) after ${retryCount + 1} attempts:`, lastErr);
+            tile.setState(3);
+            return;
+          }
 
           const canvas = document.createElement('canvas');
           canvas.width = DISPLAY_TILE_SIZE;

--- a/src/tile-retry.spec.ts
+++ b/src/tile-retry.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * tileLoadFunction 내부의 retry 로직을 검증하기 위한 테스트.
+ * source.ts의 retry 패턴을 독립적으로 추출하여 테스트한다.
+ */
+
+async function loadTileWithRetry(
+  getTile: () => Promise<{ data: Uint8ClampedArray; width: number; height: number }>,
+  retryCount: number,
+): Promise<{ data: Uint8ClampedArray; width: number; height: number } | null> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retryCount; attempt++) {
+    try {
+      return await getTile();
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  return null;
+}
+
+describe('tile retry logic', () => {
+  it('retryCount=0이면 재시도 없이 1회만 시도한다', async () => {
+    const getTile = vi.fn().mockRejectedValue(new Error('network error'));
+    const result = await loadTileWithRetry(getTile, 0);
+    expect(result).toBeNull();
+    expect(getTile).toHaveBeenCalledTimes(1);
+  });
+
+  it('retryCount=2이면 최대 3회 시도한다', async () => {
+    const getTile = vi.fn().mockRejectedValue(new Error('network error'));
+    const result = await loadTileWithRetry(getTile, 2);
+    expect(result).toBeNull();
+    expect(getTile).toHaveBeenCalledTimes(3);
+  });
+
+  it('첫 번째 시도 성공 시 즉시 반환한다', async () => {
+    const tile = { data: new Uint8ClampedArray(4), width: 1, height: 1 };
+    const getTile = vi.fn().mockResolvedValue(tile);
+    const result = await loadTileWithRetry(getTile, 3);
+    expect(result).toBe(tile);
+    expect(getTile).toHaveBeenCalledTimes(1);
+  });
+
+  it('두 번째 시도에서 성공하면 해당 결과를 반환한다', async () => {
+    const tile = { data: new Uint8ClampedArray(4), width: 1, height: 1 };
+    const getTile = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(tile);
+    const result = await loadTileWithRetry(getTile, 2);
+    expect(result).toBe(tile);
+    expect(getTile).toHaveBeenCalledTimes(2);
+  });
+
+  it('마지막 시도에서 성공하면 해당 결과를 반환한다', async () => {
+    const tile = { data: new Uint8ClampedArray(4), width: 1, height: 1 };
+    const getTile = vi.fn()
+      .mockRejectedValueOnce(new Error('fail 1'))
+      .mockRejectedValueOnce(new Error('fail 2'))
+      .mockResolvedValueOnce(tile);
+    const result = await loadTileWithRetry(getTile, 2);
+    expect(result).toBe(tile);
+    expect(getTile).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `tileRetryCount` 옵션 추가 (기본값: 0, 재시도 없음)
- `tileLoadFunction`에서 실패 시 지정 횟수만큼 재시도 후 최종 실패 처리
- retry 로직 단위 테스트 5건 추가

closes #33

## Test plan
- [x] `npm test` 통과 (45 tests)
- [ ] 네트워크 불안정 환경에서 tileRetryCount=2 설정 시 재시도 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)