### PR TITLE
feat(api): add onTileLoad callback to JP2LayerOptions

### DIFF
--- a/src/source.ts
+++ b/src/source.ts
@@ -76,6 +76,8 @@ export interface JP2LayerOptions {
   tileRetryMaxDelay?: number;
   /** 모든 재시도 소진 후 최종 실패 시 호출되는 콜백 */
   onTileError?: (info: { col: number; row: number; decodeLevel: number; error: unknown }) => void;
+  /** 타일 디코딩 성공 시 호출되는 콜백 */
+  onTileLoad?: (info: { col: number; row: number; decodeLevel: number }) => void;
 }
 
 export interface JP2LayerResult {
@@ -173,6 +175,7 @@ export async function createJP2TileLayer(
   const retryDelay = options?.tileRetryDelay ?? 500;
   const retryMaxDelay = options?.tileRetryMaxDelay ?? 5000;
   const onTileError = options?.onTileError;
+  const onTileLoad = options?.onTileLoad;
 
   const source = new TileImage({
     projection,
@@ -235,6 +238,10 @@ export async function createJP2TileLayer(
             }
             tile.setState(3);
             return;
+          }
+
+          if (onTileLoad) {
+            onTileLoad({ col, row, decodeLevel });
           }
 
           const canvas = document.createElement('canvas');

--- a/src/tile-retry.spec.ts
+++ b/src/tile-retry.spec.ts
@@ -20,13 +20,14 @@ async function loadTileWithRetry(
   return null;
 }
 
-/** source.ts의 backoff + onTileError 로직을 독립적으로 추출한 헬퍼 */
+/** source.ts의 backoff + onTileError/onTileLoad 로직을 독립적으로 추출한 헬퍼 */
 async function loadTileWithBackoff(
   getTile: () => Promise<{ data: Uint8ClampedArray; width: number; height: number }>,
   retryCount: number,
   retryDelay: number,
   retryMaxDelay: number,
   onTileError?: (info: { col: number; row: number; error: unknown }) => void,
+  onTileLoad?: (info: { col: number; row: number; decodeLevel: number }) => void,
 ): Promise<{ data: Uint8ClampedArray; width: number; height: number } | null> {
   let lastErr: unknown;
   let decoded: { data: Uint8ClampedArray; width: number; height: number } | null = null;
@@ -47,6 +48,9 @@ async function loadTileWithBackoff(
       onTileError({ col: 0, row: 0, error: lastErr });
     }
     return null;
+  }
+  if (onTileLoad) {
+    onTileLoad({ col: 0, row: 0, decodeLevel: 0 });
   }
   return decoded;
 }
@@ -199,5 +203,68 @@ describe('onTileError 콜백', () => {
     const delays = setTimeoutSpy.mock.calls.map(call => call[1]);
     expect(delays).toContain(500);
     expect(delays).toContain(1000);
+  });
+});
+
+describe('onTileLoad 콜백', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('디코딩 성공 시 onTileLoad가 정확히 한 번 호출된다', async () => {
+    const tile = { data: new Uint8ClampedArray(4), width: 1, height: 1 };
+    const getTile = vi.fn().mockResolvedValue(tile);
+    const onTileLoad = vi.fn();
+
+    const promise = loadTileWithBackoff(getTile, 2, 100, 5000, undefined, onTileLoad);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(tile);
+    expect(onTileLoad).toHaveBeenCalledTimes(1);
+    expect(onTileLoad).toHaveBeenCalledWith(
+      expect.objectContaining({ col: 0, row: 0, decodeLevel: 0 }),
+    );
+  });
+
+  it('모든 재시도 실패 시 onTileLoad가 호출되지 않는다', async () => {
+    const getTile = vi.fn().mockRejectedValue(new Error('fail'));
+    const onTileLoad = vi.fn();
+
+    const promise = loadTileWithBackoff(getTile, 2, 100, 5000, undefined, onTileLoad);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(onTileLoad).not.toHaveBeenCalled();
+  });
+
+  it('재시도 후 성공하면 onTileLoad가 호출된다', async () => {
+    const tile = { data: new Uint8ClampedArray(4), width: 1, height: 1 };
+    const getTile = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(tile);
+    const onTileLoad = vi.fn();
+
+    const promise = loadTileWithBackoff(getTile, 2, 100, 5000, undefined, onTileLoad);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(tile);
+    expect(onTileLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it('onTileLoad가 없으면 오류 없이 정상 반환한다', async () => {
+    const tile = { data: new Uint8ClampedArray(4), width: 1, height: 1 };
+    const getTile = vi.fn().mockResolvedValue(tile);
+
+    const promise = loadTileWithBackoff(getTile, 0, 100, 5000);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe(tile);
   });
 });


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `onTileLoad` 콜백 옵션 추가 (타일 디코딩 성공 시 `{ col, row, decodeLevel }` 정보와 함께 호출)
- `source.ts`의 `tileLoadFunction`에서 디코딩 성공 후 콜백 호출 로직 구현
- `onTileError`와 대칭적인 인터페이스 유지
- 단위 테스트 4건 추가 (성공/실패/재시도 후 성공/콜백 미제공 케이스)

closes #41

## Test plan
- [x] `npm test` 전체 통과 (63 tests)
- [ ] Reviewer: onTileLoad 콜백 시그니처 및 호출 시점 확인
- [ ] Tester: E2E 테스트에서 onTileLoad 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)