### PR TITLE
docs(sprint-10): update CHANGELOG and README for onProgress and initialOpacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased] — Sprint 10
+
+### Added
+- **`JP2LayerOptions.onProgress`**: 타일 로드 진행률 콜백 옵션 추가 (closes #44, PR #46)
+  - 콜백 시그니처: `(info: { loaded: number; total: number; failed: number }) => void`
+  - `loaded + failed === total` 조건으로 렌더링 완료 시점 감지 가능
+  - 프로그레스 바 등 UI 구현에 활용 가능
+- **`JP2LayerOptions.initialOpacity`**: 레이어 생성 시 초기 투명도 설정 옵션 추가 (closes #45, PR #46)
+  - 범위: 0.0 ~ 1.0 (범위 밖 값은 자동 클램프)
+  - 기본값: `1.0` (완전 불투명)
+
+---
+
 ## [Unreleased] — Sprint 9
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ const result = await createJP2TileLayer(provider, options);
 | `tileRetryMaxDelay` | `number` | `5000` | 재시도 최대 delay 상한 (ms) |
 | `onTileError` | `(info: { col, row, decodeLevel, error }) => void` | - | 모든 재시도 소진 후 최종 실패 시 호출되는 콜백 |
 | `onTileLoad` | `(info: { col, row, decodeLevel }) => void` | - | 타일 디코딩 성공 시 호출되는 콜백 |
+| `onProgress` | `(info: { loaded, total, failed }) => void` | - | 타일 로드 진행률 콜백 (loaded+failed === total 시 완료) |
+| `initialOpacity` | `number` | `1.0` | 레이어 초기 투명도 (0.0 ~ 1.0) |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG.md에 Sprint 10 (onProgress, initialOpacity) 변경사항 추가
- README.md의 JP2LayerOptions 테이블에 신규 옵션 2개 추가: `onProgress`, `initialOpacity`

closes #44
closes #45

## Test plan
- [ ] CHANGELOG.md 내용이 실제 PR #46 변경사항과 일치하는지 확인
- [ ] README.md API 테이블의 타입 시그니처 정확성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)