### PR TITLE
docs(sprint-11): update docs for tileLoadTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ const result = await createJP2TileLayer(provider, options);
 | `onTileError` | `(info: { col, row, decodeLevel, error }) => void` | - | 모든 재시도 소진 후 최종 실패 시 호출되는 콜백 |
 | `onTileLoad` | `(info: { col, row, decodeLevel }) => void` | - | 타일 디코딩 성공 시 호출되는 콜백 |
 | `onProgress` | `(info: { loaded, total, failed }) => void` | - | 타일 로드 진행률 콜백 (loaded+failed === total 시 완료) |
+| `tileLoadTimeout` | `number` | - | 개별 타일 로드 타임아웃 (ms). 초과 시 `Error('Tile load timeout')` throw. 미지정 시 타임아웃 없음 |
 | `initialOpacity` | `number` | `1.0` | 레이어 초기 투명도 (0.0 ~ 1.0) |
 
 #### 반환값 (`JP2LayerResult`)


### PR DESCRIPTION
## Summary
- README.md의 JP2LayerOptions 테이블에 `tileLoadTimeout` 옵션 추가

closes #48

## Changes
- `tileLoadTimeout` 옵션 문서화: 개별 타일 로드 타임아웃(ms), 초과 시 `Error('Tile load timeout')` throw, 미지정 시 타임아웃 없음

## Notes
- CHANGELOG.md는 PR #49에서 이미 업데이트됨
- `src/source.ts`의 JSDoc 주석은 PR #49에서 이미 추가됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)