### PR TITLE
docs(sprint-12): update CHANGELOG and README for requestHeaders option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 12
+
+### Added
+- **`RangeTileProvider` 생성자 옵션 `requestHeaders`**: JP2 파일 Range 요청 시 커스텀 HTTP 헤더 전달 기능 추가 (closes #51, PR #52)
+  - 인증 토큰(`Authorization`) 등 서버 인증이 필요한 환경에서 활용 가능
+  - `Range` 헤더는 항상 마지막에 적용되어 커스텀 헤더로 덮어쓸 수 없음
+  - `parseJP2` 및 `fetchTileData` 내부 함수에 `extraHeaders` 파라미터로 전파
+
+---
+
 ## [Unreleased] — Sprint 11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,10 +93,16 @@ const provider = new RangeTileProvider(url, options);
 | 옵션 | 타입 | 기본값 | 설명 |
 |------|------|--------|------|
 | `cacheTTL` | `number` | `86400000` (24시간) | IndexedDB 캐시 TTL (밀리초) |
+| `requestHeaders` | `Record<string, string>` | - | JP2 파일 fetch 시 추가할 HTTP 헤더 (인증 토큰 등). `Range` 헤더는 항상 마지막에 적용되어 덮어쓸 수 없음 |
 
 ```typescript
 // TTL을 1시간으로 설정
 const provider = new RangeTileProvider(url, { cacheTTL: 60 * 60 * 1000 });
+
+// 인증 헤더 추가
+const provider = new RangeTileProvider(url, {
+  requestHeaders: { Authorization: 'Bearer <token>' },
+});
 ```
 
 #### 정적 메서드

--- a/src/range-tile-provider.ts
+++ b/src/range-tile-provider.ts
@@ -115,6 +115,15 @@ class DecodedTileCache {
   }
 }
 
+/**
+ * HTTP Range 요청을 사용하여 JP2 파일을 타일 단위로 부분 조회하는 타일 프로바이더.
+ *
+ * @example
+ * const provider = new RangeTileProvider('path/to/file.jp2', {
+ *   cacheTTL: 60 * 60 * 1000,
+ *   requestHeaders: { Authorization: 'Bearer <token>' },
+ * });
+ */
 export class RangeTileProvider implements TileProvider {
   private info!: JP2Info;
   private pool = new WorkerPool();
@@ -135,6 +144,13 @@ export class RangeTileProvider implements TileProvider {
 
   private requestHeaders?: Record<string, string>;
 
+  /**
+   * @param url - JP2 파일 URL
+   * @param options.cacheTTL - IndexedDB 캐시 TTL (밀리초, 기본값: 24시간)
+   * @param options.minValue - 픽셀 정규화 최소값 (미지정 시 자동 계산)
+   * @param options.maxValue - 픽셀 정규화 최대값 (미지정 시 자동 계산)
+   * @param options.requestHeaders - fetch 요청에 추가할 HTTP 헤더. `Range` 헤더는 덮어쓸 수 없음
+   */
   constructor(private url: string, options?: { cacheTTL?: number; minValue?: number; maxValue?: number; requestHeaders?: Record<string, string> }) {
     this.cacheTTL = options?.cacheTTL ?? DEFAULT_TTL_MS;
     this.userMin = options?.minValue;


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 12 섹션 추가: `RangeTileProvider.requestHeaders` 옵션 (PR #52, closes #51)
- README `RangeTileProvider` 생성자 옵션 테이블에 `requestHeaders` 항목 및 사용 예제 추가
- `RangeTileProvider` 클래스 및 생성자에 JSDoc 주석 추가

## 관련 이슈
- PR #52: feat(api): add requestHeaders option to RangeTileProvider
- 이슈 #53 (JP2LayerOptions.requestHeaders 누락)은 다음 스프린트 백로그에 등록됨

## Test plan
- [ ] README의 requestHeaders 옵션 설명이 실제 구현과 일치하는지 확인
- [ ] CHANGELOG Sprint 12 섹션 내용 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)