### PR TITLE
feat(api): add requestHeaders option to JP2LayerOptions

### DIFF
--- a/src/jp2layer-request-headers.test.ts
+++ b/src/jp2layer-request-headers.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * createJP2TileLayer에 URL string + requestHeaders를 전달하면
+ * 내부에서 RangeTileProvider가 올바르게 생성되는지 검증한다.
+ */
+
+const constructorSpy = vi.fn();
+const mockInit = vi.fn();
+const mockDestroy = vi.fn();
+
+vi.mock('./range-tile-provider', () => ({
+  RangeTileProvider: class MockRangeTileProvider {
+    constructor(...args: unknown[]) {
+      constructorSpy(...args);
+    }
+    init = mockInit;
+    destroy = mockDestroy;
+  },
+}));
+
+describe('createJP2TileLayer with URL string and requestHeaders', () => {
+  it('should create RangeTileProvider with requestHeaders when URL string is provided', async () => {
+    constructorSpy.mockClear();
+    mockInit.mockRejectedValueOnce(new Error('stop here'));
+
+    const { createJP2TileLayer } = await import('./source');
+    const headers = { Authorization: 'Bearer test-token' };
+
+    await expect(
+      createJP2TileLayer('http://example.com/test.jp2', { requestHeaders: headers }),
+    ).rejects.toThrow('stop here');
+
+    expect(constructorSpy).toHaveBeenCalledWith('http://example.com/test.jp2', {
+      minValue: undefined,
+      maxValue: undefined,
+      requestHeaders: headers,
+    });
+  });
+
+  it('should not create RangeTileProvider when TileProvider object is passed', async () => {
+    constructorSpy.mockClear();
+
+    const { createJP2TileLayer } = await import('./source');
+    const mockProvider = {
+      init: vi.fn().mockRejectedValue(new Error('stop')),
+      destroy: vi.fn(),
+    };
+
+    await expect(
+      createJP2TileLayer(mockProvider, { requestHeaders: { 'X-Key': 'val' } }),
+    ).rejects.toThrow('stop');
+
+    expect(constructorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/range-tile-provider.ts
+++ b/src/range-tile-provider.ts
@@ -265,7 +265,7 @@ export class RangeTileProvider implements TileProvider {
     const tileIndex = this.info.tiles.find(t => t.tileId === tileId);
     if (!tileIndex) throw new Error(`Tile ${tileId} not found`);
 
-    const tileData = await fetchTileData(this.url, tileIndex);
+    const tileData = await fetchTileData(this.url, tileIndex, this.requestHeaders);
 
     const actualW = Math.min(tileWidth, imgW - col * tileWidth);
     const actualH = Math.min(tileHeight, imgH - row * tileHeight);

--- a/src/source.ts
+++ b/src/source.ts
@@ -7,6 +7,7 @@ import proj4 from 'proj4';
 import type Tile from 'ol/Tile';
 import ImageTile from 'ol/ImageTile';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
+import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
 
 async function ensureProjection(
@@ -84,6 +85,8 @@ export interface JP2LayerOptions {
   tileLoadTimeout?: number;
   /** 레이어 초기 투명도 (0.0 ~ 1.0, 기본값: 1.0) */
   initialOpacity?: number;
+  /** HTTP 요청에 추가할 커스텀 헤더 (URL 문자열로 호출 시 RangeTileProvider에 전달) */
+  requestHeaders?: Record<string, string>;
 }
 
 export interface JP2LayerResult {
@@ -97,9 +100,17 @@ export interface JP2LayerResult {
 }
 
 export async function createJP2TileLayer(
-  provider: TileProvider,
+  providerOrUrl: TileProvider | string,
   options?: JP2LayerOptions,
 ): Promise<JP2LayerResult> {
+  const provider: TileProvider =
+    typeof providerOrUrl === 'string'
+      ? new RangeTileProvider(providerOrUrl, {
+          minValue: options?.minValue,
+          maxValue: options?.maxValue,
+          requestHeaders: options?.requestHeaders,
+        })
+      : providerOrUrl;
   const info = await provider.init();
   const { width, height, tileWidth, tileHeight, tilesX, tilesY, geoInfo } = info;
 


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `requestHeaders?: Record<string, string>` 필드 추가
- `createJP2TileLayer`가 URL string을 첫 번째 인자로 받을 수 있도록 오버로드 추가 — 내부에서 `RangeTileProvider`를 자동 생성하며 `requestHeaders` 전달
- `RangeTileProvider._decodeTile`에서 누락된 `requestHeaders` 전달 버그 수정

closes #53

## Test plan
- [x] `createJP2TileLayer(url, { requestHeaders })` 호출 시 `RangeTileProvider` 생성자에 headers 전달 확인
- [x] `TileProvider` 객체 전달 시 `RangeTileProvider` 미생성 확인
- [x] 기존 테스트 93개 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)