### PR TITLE
feat(api): add onTileLoadStart callback to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { JP2LayerOptions } from './source';
 
 /**
- * tileLoadTimeout 로직을 직접 테스트한다.
+ * JP2LayerOptions 타입 테스트 및 tileLoadTimeout 로직을 직접 테스트한다.
  * createJP2TileLayer는 OpenLayers DOM 의존이 있으므로,
  * 타임아웃 핵심 로직(clearTimeout 패턴)을 단위 테스트한다.
  */
@@ -99,3 +100,32 @@ describe('tileLoadTimeout', () => {
     });
   });
 });
+
+describe('onTileLoadStart callback', () => {
+  it('should be defined in JP2LayerOptions type', () => {
+    const opts: JP2LayerOptions = {
+      onTileLoadStart: ({ col, row, decodeLevel }) => {
+        // type-check: all fields should be numbers
+        const _c: number = col;
+        const _r: number = row;
+        const _d: number = decodeLevel;
+        void (_c + _r + _d);
+      },
+    };
+    expect(opts.onTileLoadStart).toBeDefined();
+  });
+
+  it('should invoke callback with correct info', () => {
+    const calls: Array<{ col: number; row: number; decodeLevel: number }> = [];
+    const onTileLoadStart: JP2LayerOptions['onTileLoadStart'] = (info) => {
+      calls.push(info);
+    };
+
+    // Simulate the call pattern from source.ts
+    onTileLoadStart!({ col: 2, row: 3, decodeLevel: 1 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ col: 2, row: 3, decodeLevel: 1 });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -87,6 +87,8 @@ export interface JP2LayerOptions {
   initialOpacity?: number;
   /** HTTP 요청에 추가할 커스텀 헤더 (URL 문자열로 호출 시 RangeTileProvider에 전달) */
   requestHeaders?: Record<string, string>;
+  /** 타일 로드 시작 시 호출되는 콜백 (sem.acquire 이후, getTile 직전) */
+  onTileLoadStart?: (info: { col: number; row: number; decodeLevel: number }) => void;
 }
 
 export interface JP2LayerResult {
@@ -194,6 +196,7 @@ export async function createJP2TileLayer(
   const tileLoadTimeout = options?.tileLoadTimeout;
   const onTileError = options?.onTileError;
   const onTileLoad = options?.onTileLoad;
+  const onTileLoadStart = options?.onTileLoadStart;
   const onProgress = options?.onProgress;
 
   // Progress tracking state
@@ -248,6 +251,9 @@ export async function createJP2TileLayer(
         emitProgress();
         await sem.acquire();
         try {
+          if (onTileLoadStart) {
+            onTileLoadStart({ col, row, decodeLevel });
+          }
           let decoded;
           let lastErr: unknown;
           for (let attempt = 0; attempt <= retryCount; attempt++) {


### PR DESCRIPTION
## Summary
- JP2LayerOptions에 `onTileLoadStart` 콜백 추가: `{ col, row, decodeLevel }` 정보와 함께 타일 로드 시작 시점에 호출
- sem.acquire() 이후, provider.getTile() 직전에 호출되어 타일 생명주기 추적 완성
- 단위 테스트 추가 (source.test.ts)

## Test plan
- [x] `npm test` 통과
- [x] TypeScript 타입 체크 통과
- [ ] E2E: onTileLoadStart 콜백이 타일 로드 전에 정상 호출되는지 확인

closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)