### PR TITLE
docs(sprint-16): update CHANGELOG and README for visible option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 16
+
+### Added
+- **`JP2LayerOptions.visible`**: 레이어 초기 가시성 옵션 추가 (closes #68, PR #69)
+  - 타입: `boolean`, 기본값: `true`
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `visible` 옵션에 전달
+  - `false`로 설정 시 레이어가 초기에 숨겨진 상태로 생성됨
+
+---
+
 ## [Unreleased] — Sprint 15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `onTileLoadStart` | `(info: { col, row, decodeLevel }) => void` | - | 타일 로드 시작 시 호출되는 콜백 (`sem.acquire` 이후, `getTile` 직전) |
 | `attributions` | `string \| string[]` | - | OpenLayers TileImage 소스에 표시할 저작권/출처 정보 |
 | `bands` | `[r, g, b]` | - | 다중 채널 이미지에서 RGB에 매핑할 밴드 인덱스 (0-based). 예: `[3, 2, 1]`. `componentCount >= 3`에만 적용 |
+| `visible` | `boolean` | `true` | 레이어 초기 가시성. `false`로 설정 시 레이어가 숨겨진 상태로 생성됨 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 16 섹션 추가: `JP2LayerOptions.visible` (PR #69, closes #68)
- README `JP2LayerOptions` 테이블에 `visible` 항목 추가

## Test plan
- [x] `npm test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)