### PR TITLE
docs(sprint-17): update CHANGELOG and README for zIndex option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 17
+
+### Added
+- **`JP2LayerOptions.zIndex`**: 레이어 렌더링 순서 옵션 추가 (closes #71, PR #72)
+  - 타입: `number`
+  - 숫자가 클수록 위에 렌더링 (OpenLayers 표준 `zIndex` 옵션과 동일)
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `zIndex` 옵션에 전달
+  - 복수 JP2 레이어 간 렌더링 순서 제어에 활용
+
+---
+
 ## [Unreleased] — Sprint 16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `attributions` | `string \| string[]` | - | OpenLayers TileImage 소스에 표시할 저작권/출처 정보 |
 | `bands` | `[r, g, b]` | - | 다중 채널 이미지에서 RGB에 매핑할 밴드 인덱스 (0-based). 예: `[3, 2, 1]`. `componentCount >= 3`에만 적용 |
 | `visible` | `boolean` | `true` | 레이어 초기 가시성. `false`로 설정 시 레이어가 숨겨진 상태로 생성됨 |
+| `zIndex` | `number` | - | 레이어 렌더링 순서. 숫자가 클수록 위에 렌더링 (OpenLayers 표준 `zIndex` 옵션) |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 17 섹션 추가: `JP2LayerOptions.zIndex` (PR #72, closes #71)
- README `JP2LayerOptions` 테이블에 `zIndex` 항목 추가

## Test plan
- [x] `npm test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)