### PR TITLE
feat(api): add preload option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -309,6 +309,50 @@ describe('visible option', () => {
   });
 });
 
+describe('preload option', () => {
+  it('should accept a numeric preload value', () => {
+    const opts: JP2LayerOptions = { preload: 2 };
+    expect(opts.preload).toBe(2);
+  });
+
+  it('should accept preload: 0', () => {
+    const opts: JP2LayerOptions = { preload: 0 };
+    expect(opts.preload).toBe(0);
+  });
+
+  it('should accept preload: Infinity', () => {
+    const opts: JP2LayerOptions = { preload: Infinity };
+    expect(opts.preload).toBe(Infinity);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.preload).toBeUndefined();
+  });
+
+  describe('resolvePreload logic (options?.preload ?? 0)', () => {
+    function resolvePreload(options?: JP2LayerOptions): number {
+      return options?.preload ?? 0;
+    }
+
+    it('returns the value when preload is set', () => {
+      expect(resolvePreload({ preload: 3 })).toBe(3);
+    });
+
+    it('returns 0 when preload is omitted', () => {
+      expect(resolvePreload({})).toBe(0);
+    });
+
+    it('returns 0 when options is undefined', () => {
+      expect(resolvePreload(undefined)).toBe(0);
+    });
+
+    it('returns Infinity when preload is Infinity', () => {
+      expect(resolvePreload({ preload: Infinity })).toBe(Infinity);
+    });
+  });
+});
+
 describe('zIndex option', () => {
   it('should accept a numeric zIndex', () => {
     const opts: JP2LayerOptions = { zIndex: 10 };

--- a/src/source.ts
+++ b/src/source.ts
@@ -99,6 +99,8 @@ export interface JP2LayerOptions {
   visible?: boolean;
   /** 레이어 렌더링 순서 (숫자가 클수록 위에 렌더링, OpenLayers 표준 옵션) */
   zIndex?: number;
+  /** 저해상도 타일 미리 로드 레벨 수 (기본값: 0, 미리 로드 없음). Infinity로 전체 피라미드 미리 로드 가능 */
+  preload?: number;
 }
 
 export interface JP2LayerResult {
@@ -428,10 +430,11 @@ export async function createJP2TileLayer(
   const visible = options?.visible ?? true;
 
   const zIndex = options?.zIndex;
+  const preload = options?.preload ?? 0;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex })
-    : new TileLayer({ source, extent, opacity, visible, zIndex });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `preload?: number` 옵션 추가 (기본값: 0)
- `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `preload` 옵션으로 전달
- 단위 테스트 8개 추가 (타입 검증, 기본값 로직, Infinity 지원)

closes #74

## Test plan
- [x] `npm test` 132 테스트 전체 통과
- [ ] E2E: `preload: 2` 설정 후 줌 변경 시 저해상도 타일이 미리 로드되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)