### PR TITLE
docs(sprint-18): update CHANGELOG and README for preload option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 18
+
+### Added
+- **`JP2LayerOptions.preload`**: 저해상도 타일 미리 로드 레벨 수 옵션 추가 (closes #74, PR #75)
+  - 타입: `number`, 기본값: `0` (미리 로드 없음)
+  - `Infinity`로 설정 시 전체 피라미드 미리 로드
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `preload` 옵션에 전달
+  - 줌 변경 시 저해상도 타일을 먼저 표시하여 빈 타일 영역 감소에 활용
+
+---
+
 ## [Unreleased] — Sprint 17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `bands` | `[r, g, b]` | - | 다중 채널 이미지에서 RGB에 매핑할 밴드 인덱스 (0-based). 예: `[3, 2, 1]`. `componentCount >= 3`에만 적용 |
 | `visible` | `boolean` | `true` | 레이어 초기 가시성. `false`로 설정 시 레이어가 숨겨진 상태로 생성됨 |
 | `zIndex` | `number` | - | 레이어 렌더링 순서. 숫자가 클수록 위에 렌더링 (OpenLayers 표준 `zIndex` 옵션) |
+| `preload` | `number` | `0` | 저해상도 타일 미리 로드 레벨 수. `Infinity`로 전체 피라미드 미리 로드 가능 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 18 섹션 추가: `JP2LayerOptions.preload` (PR #75, closes #74)
- README `JP2LayerOptions` 테이블에 `preload` 항목 추가

## Test plan
- [x] `npm test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)