### PR TITLE
feat(api): add className option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -353,6 +353,36 @@ describe('preload option', () => {
   });
 });
 
+describe('className option', () => {
+  it('should accept a string className', () => {
+    const opts: JP2LayerOptions = { className: 'my-custom-layer' };
+    expect(opts.className).toBe('my-custom-layer');
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.className).toBeUndefined();
+  });
+
+  describe('resolveClassName logic (options?.className)', () => {
+    function resolveClassName(options?: JP2LayerOptions): string | undefined {
+      return options?.className;
+    }
+
+    it('returns the value when className is set', () => {
+      expect(resolveClassName({ className: 'jp2-overlay' })).toBe('jp2-overlay');
+    });
+
+    it('returns undefined when className is omitted (OL uses default ol-layer)', () => {
+      expect(resolveClassName({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveClassName(undefined)).toBeUndefined();
+    });
+  });
+});
+
 describe('zIndex option', () => {
   it('should accept a numeric zIndex', () => {
     const opts: JP2LayerOptions = { zIndex: 10 };

--- a/src/source.ts
+++ b/src/source.ts
@@ -101,6 +101,8 @@ export interface JP2LayerOptions {
   zIndex?: number;
   /** 저해상도 타일 미리 로드 레벨 수 (기본값: 0, 미리 로드 없음). Infinity로 전체 피라미드 미리 로드 가능 */
   preload?: number;
+  /** 레이어 DOM 요소에 적용할 CSS 클래스명 (기본값: OpenLayers 기본값 'ol-layer') */
+  className?: string;
 }
 
 export interface JP2LayerResult {
@@ -431,10 +433,11 @@ export async function createJP2TileLayer(
 
   const zIndex = options?.zIndex;
   const preload = options?.preload ?? 0;
+  const className = options?.className;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `className?: string` 옵션 추가
- `TileLayer` 생성 시 `className`을 전달하여 레이어 DOM 요소에 커스텀 CSS 클래스명 설정 가능
- 미지정 시 OpenLayers 기본값 `'ol-layer'` 적용

closes #77

## Test plan
- [x] `className` 옵션 타입 테스트 추가
- [x] `resolveClassName` 로직 테스트 (설정/미설정/undefined)
- [x] `npm test` 전체 통과 (137 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)