### PR TITLE
docs(sprint-19): update CHANGELOG and README for className option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 19
+
+### Added
+- **`JP2LayerOptions.className`**: 레이어 DOM 요소에 적용할 CSS 클래스명 옵션 추가 (closes #77, PR #78)
+  - 타입: `string`, 기본값: OpenLayers 기본값 `'ol-layer'`
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `className` 옵션에 전달
+  - 복수 JP2 레이어를 CSS로 개별 제어하거나 커스텀 스타일 적용 시 활용
+
+---
+
 ## [Unreleased] — Sprint 18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `visible` | `boolean` | `true` | 레이어 초기 가시성. `false`로 설정 시 레이어가 숨겨진 상태로 생성됨 |
 | `zIndex` | `number` | - | 레이어 렌더링 순서. 숫자가 클수록 위에 렌더링 (OpenLayers 표준 `zIndex` 옵션) |
 | `preload` | `number` | `0` | 저해상도 타일 미리 로드 레벨 수. `Infinity`로 전체 피라미드 미리 로드 가능 |
+| `className` | `string` | `'ol-layer'` | 레이어 DOM 요소에 적용할 CSS 클래스명. 복수 레이어 CSS 개별 제어에 활용 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 19 섹션 추가: `JP2LayerOptions.className` (PR #78, closes #77)
- README `JP2LayerOptions` 테이블에 `className` 항목 추가

## Test plan
- [x] `npm test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)