### PR TITLE
feat(api): add minZoom/maxZoom options to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -383,6 +383,84 @@ describe('className option', () => {
   });
 });
 
+describe('minZoom option', () => {
+  it('should accept a numeric minZoom', () => {
+    const opts: JP2LayerOptions = { minZoom: 5 };
+    expect(opts.minZoom).toBe(5);
+  });
+
+  it('should accept minZoom: 0', () => {
+    const opts: JP2LayerOptions = { minZoom: 0 };
+    expect(opts.minZoom).toBe(0);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.minZoom).toBeUndefined();
+  });
+
+  describe('resolveMinZoom logic (options?.minZoom)', () => {
+    function resolveMinZoom(options?: JP2LayerOptions): number | undefined {
+      return options?.minZoom;
+    }
+
+    it('returns the value when minZoom is set', () => {
+      expect(resolveMinZoom({ minZoom: 3 })).toBe(3);
+    });
+
+    it('returns undefined when minZoom is omitted', () => {
+      expect(resolveMinZoom({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveMinZoom(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('maxZoom option', () => {
+  it('should accept a numeric maxZoom', () => {
+    const opts: JP2LayerOptions = { maxZoom: 18 };
+    expect(opts.maxZoom).toBe(18);
+  });
+
+  it('should accept maxZoom: 0', () => {
+    const opts: JP2LayerOptions = { maxZoom: 0 };
+    expect(opts.maxZoom).toBe(0);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.maxZoom).toBeUndefined();
+  });
+
+  describe('resolveMaxZoom logic (options?.maxZoom)', () => {
+    function resolveMaxZoom(options?: JP2LayerOptions): number | undefined {
+      return options?.maxZoom;
+    }
+
+    it('returns the value when maxZoom is set', () => {
+      expect(resolveMaxZoom({ maxZoom: 15 })).toBe(15);
+    });
+
+    it('returns undefined when maxZoom is omitted', () => {
+      expect(resolveMaxZoom({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveMaxZoom(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('minZoom and maxZoom combined', () => {
+  it('should accept both minZoom and maxZoom together', () => {
+    const opts: JP2LayerOptions = { minZoom: 3, maxZoom: 15 };
+    expect(opts.minZoom).toBe(3);
+    expect(opts.maxZoom).toBe(15);
+  });
+});
+
 describe('zIndex option', () => {
   it('should accept a numeric zIndex', () => {
     const opts: JP2LayerOptions = { zIndex: 10 };

--- a/src/source.ts
+++ b/src/source.ts
@@ -103,6 +103,10 @@ export interface JP2LayerOptions {
   preload?: number;
   /** 레이어 DOM 요소에 적용할 CSS 클래스명 (기본값: OpenLayers 기본값 'ol-layer') */
   className?: string;
+  /** 레이어가 표시되는 최소 줌 레벨 (이 레벨 미만에서는 숨김) */
+  minZoom?: number;
+  /** 레이어가 표시되는 최대 줌 레벨 (이 레벨 초과 시 숨김) */
+  maxZoom?: number;
 }
 
 export interface JP2LayerResult {
@@ -434,10 +438,12 @@ export async function createJP2TileLayer(
   const zIndex = options?.zIndex;
   const preload = options?.preload ?? 0;
   const className = options?.className;
+  const minZoom = options?.minZoom;
+  const maxZoom = options?.maxZoom;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `minZoom`, `maxZoom` 옵션 추가
- `createJP2TileLayer`에서 두 옵션을 OpenLayers `TileLayer`에 전달
- 단위 테스트 추가 (타입 검증 및 resolve 로직)

closes #80

## Test plan
- [x] `npm test` 전체 통과 (150 tests)
- [ ] 실제 JP2 레이어에서 minZoom/maxZoom 설정 시 줌 레벨 범위 밖에서 레이어가 숨겨지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)