### PR TITLE
feat(api): add updateWhileAnimating/updateWhileInteracting options

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -496,3 +496,88 @@ describe('zIndex option', () => {
   });
 });
 
+describe('updateWhileAnimating option', () => {
+  it('should accept updateWhileAnimating: true', () => {
+    const opts: JP2LayerOptions = { updateWhileAnimating: true };
+    expect(opts.updateWhileAnimating).toBe(true);
+  });
+
+  it('should accept updateWhileAnimating: false', () => {
+    const opts: JP2LayerOptions = { updateWhileAnimating: false };
+    expect(opts.updateWhileAnimating).toBe(false);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.updateWhileAnimating).toBeUndefined();
+  });
+
+  describe('resolveUpdateWhileAnimating logic', () => {
+    function resolveUpdateWhileAnimating(options?: JP2LayerOptions): boolean | undefined {
+      return options?.updateWhileAnimating;
+    }
+
+    it('returns true when set to true', () => {
+      expect(resolveUpdateWhileAnimating({ updateWhileAnimating: true })).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(resolveUpdateWhileAnimating({ updateWhileAnimating: false })).toBe(false);
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveUpdateWhileAnimating({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveUpdateWhileAnimating(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('updateWhileInteracting option', () => {
+  it('should accept updateWhileInteracting: true', () => {
+    const opts: JP2LayerOptions = { updateWhileInteracting: true };
+    expect(opts.updateWhileInteracting).toBe(true);
+  });
+
+  it('should accept updateWhileInteracting: false', () => {
+    const opts: JP2LayerOptions = { updateWhileInteracting: false };
+    expect(opts.updateWhileInteracting).toBe(false);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.updateWhileInteracting).toBeUndefined();
+  });
+
+  describe('resolveUpdateWhileInteracting logic', () => {
+    function resolveUpdateWhileInteracting(options?: JP2LayerOptions): boolean | undefined {
+      return options?.updateWhileInteracting;
+    }
+
+    it('returns true when set to true', () => {
+      expect(resolveUpdateWhileInteracting({ updateWhileInteracting: true })).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(resolveUpdateWhileInteracting({ updateWhileInteracting: false })).toBe(false);
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveUpdateWhileInteracting({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveUpdateWhileInteracting(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('updateWhileAnimating and updateWhileInteracting combined', () => {
+  it('should accept both options together', () => {
+    const opts: JP2LayerOptions = { updateWhileAnimating: true, updateWhileInteracting: true };
+    expect(opts.updateWhileAnimating).toBe(true);
+    expect(opts.updateWhileInteracting).toBe(true);
+  });
+});

--- a/src/source.ts
+++ b/src/source.ts
@@ -107,6 +107,10 @@ export interface JP2LayerOptions {
   minZoom?: number;
   /** 레이어가 표시되는 최대 줌 레벨 (이 레벨 초과 시 숨김) */
   maxZoom?: number;
+  /** 애니메이션 중 타일 업데이트 여부 (기본값: false) */
+  updateWhileAnimating?: boolean;
+  /** 사용자 인터랙션 중 타일 업데이트 여부 (기본값: false) */
+  updateWhileInteracting?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -440,10 +444,20 @@ export async function createJP2TileLayer(
   const className = options?.className;
   const minZoom = options?.minZoom;
   const maxZoom = options?.maxZoom;
+  const updateWhileAnimating = options?.updateWhileAnimating;
+  const updateWhileInteracting = options?.updateWhileInteracting;
 
+  // updateWhileAnimating/updateWhileInteracting are not in TileLayer's type definition
+  // but are recognized at runtime by OpenLayers' Layer base class.
+  const extraOpts = {
+    ...(updateWhileAnimating !== undefined && { updateWhileAnimating }),
+    ...(updateWhileInteracting !== undefined && { updateWhileInteracting }),
+  };
+
+  const baseLayerOpts = { source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, ...extraOpts };
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom });
+    ? new TileLayer(baseLayerOpts as Parameters<typeof TileLayer.prototype.setProperties>[0] & { source: TileImage })
+    : new TileLayer({ ...baseLayerOpts, extent } as Parameters<typeof TileLayer.prototype.setProperties>[0] & { source: TileImage });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `updateWhileAnimating`/`updateWhileInteracting` boolean 옵션 추가
- `createJP2TileLayer`에서 `TileLayer` 생성 시 두 옵션 전달
- 단위 테스트 추가 (타입 검증 + resolve 로직)

closes #83

## Test plan
- [x] `npm test` — 165개 전체 통과
- [x] `tsc --noEmit` — 타입 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)