### PR TITLE
feat(api): add updateWhileAnimating/updateWhileInteracting options to JP2LayerOptions (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 23
+
+### Added
+- **`JP2LayerOptions.updateWhileAnimating`**: 애니메이션 중 타일 업데이트 여부 옵션 추가 (closes #88)
+  - 타입: `boolean`, 기본값: `false`
+  - `true`로 설정하면 지도 애니메이션(패닝/줌) 중에도 타일을 계속 업데이트
+- **`JP2LayerOptions.updateWhileInteracting`**: 인터랙션 중 타일 업데이트 여부 옵션 추가 (closes #88)
+  - 타입: `boolean`, 기본값: `false`
+  - `true`로 설정하면 사용자 인터랙션(드래그/핀치 줌) 중에도 타일을 계속 업데이트
+
+---
+
 ## [Unreleased] — Sprint 20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `className` | `string` | `'ol-layer'` | 레이어 DOM 요소에 적용할 CSS 클래스명. 복수 레이어 CSS 개별 제어에 활용 |
 | `minZoom` | `number` | - | 레이어가 표시되는 최소 줌 레벨. 이 레벨 미만에서는 레이어가 숨김 |
 | `maxZoom` | `number` | - | 레이어가 표시되는 최대 줌 레벨. 이 레벨 초과 시 레이어가 숨김 |
+| `updateWhileAnimating` | `boolean` | `false` | 애니메이션 중 타일 업데이트 여부. `true` 시 패닝/줌 애니메이션 중에도 타일 업데이트 |
+| `updateWhileInteracting` | `boolean` | `false` | 인터랙션 중 타일 업데이트 여부. `true` 시 드래그/핀치 줌 중에도 타일 업데이트 |
 
 #### 반환값 (`JP2LayerResult`)
 

--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -529,6 +529,92 @@ describe('maxResolution and minResolution combined', () => {
   });
 });
 
+describe('updateWhileAnimating option', () => {
+  it('should accept updateWhileAnimating: true', () => {
+    const opts: JP2LayerOptions = { updateWhileAnimating: true };
+    expect(opts.updateWhileAnimating).toBe(true);
+  });
+
+  it('should accept updateWhileAnimating: false', () => {
+    const opts: JP2LayerOptions = { updateWhileAnimating: false };
+    expect(opts.updateWhileAnimating).toBe(false);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.updateWhileAnimating).toBeUndefined();
+  });
+
+  describe('resolveUpdateWhileAnimating logic (options?.updateWhileAnimating)', () => {
+    function resolveUpdateWhileAnimating(options?: JP2LayerOptions): boolean | undefined {
+      return options?.updateWhileAnimating;
+    }
+
+    it('returns true when set to true', () => {
+      expect(resolveUpdateWhileAnimating({ updateWhileAnimating: true })).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(resolveUpdateWhileAnimating({ updateWhileAnimating: false })).toBe(false);
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveUpdateWhileAnimating({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveUpdateWhileAnimating(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('updateWhileInteracting option', () => {
+  it('should accept updateWhileInteracting: true', () => {
+    const opts: JP2LayerOptions = { updateWhileInteracting: true };
+    expect(opts.updateWhileInteracting).toBe(true);
+  });
+
+  it('should accept updateWhileInteracting: false', () => {
+    const opts: JP2LayerOptions = { updateWhileInteracting: false };
+    expect(opts.updateWhileInteracting).toBe(false);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.updateWhileInteracting).toBeUndefined();
+  });
+
+  describe('resolveUpdateWhileInteracting logic (options?.updateWhileInteracting)', () => {
+    function resolveUpdateWhileInteracting(options?: JP2LayerOptions): boolean | undefined {
+      return options?.updateWhileInteracting;
+    }
+
+    it('returns true when set to true', () => {
+      expect(resolveUpdateWhileInteracting({ updateWhileInteracting: true })).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(resolveUpdateWhileInteracting({ updateWhileInteracting: false })).toBe(false);
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveUpdateWhileInteracting({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveUpdateWhileInteracting(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('updateWhileAnimating and updateWhileInteracting combined', () => {
+  it('should accept both options together', () => {
+    const opts: JP2LayerOptions = { updateWhileAnimating: true, updateWhileInteracting: true };
+    expect(opts.updateWhileAnimating).toBe(true);
+    expect(opts.updateWhileInteracting).toBe(true);
+  });
+});
+
 describe('zIndex option', () => {
   it('should accept a numeric zIndex', () => {
     const opts: JP2LayerOptions = { zIndex: 10 };

--- a/src/source.ts
+++ b/src/source.ts
@@ -111,6 +111,10 @@ export interface JP2LayerOptions {
   maxResolution?: number;
   /** 레이어가 표시되는 최소 해상도 (map units per pixel). 이 해상도 미만 시 숨김 */
   minResolution?: number;
+  /** 애니메이션 중 타일 업데이트 여부 (기본값: false) */
+  updateWhileAnimating?: boolean;
+  /** 인터랙션 중 타일 업데이트 여부 (기본값: false) */
+  updateWhileInteracting?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -446,10 +450,12 @@ export async function createJP2TileLayer(
   const maxZoom = options?.maxZoom;
   const maxResolution = options?.maxResolution;
   const minResolution = options?.minResolution;
+  const updateWhileAnimating = options?.updateWhileAnimating;
+  const updateWhileInteracting = options?.updateWhileInteracting;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `updateWhileAnimating`/`updateWhileInteracting` boolean 옵션 추가
- `createJP2TileLayer`에서 `TileLayer` 생성 시 두 옵션 전달
- 단위 테스트, CHANGELOG, README 업데이트

closes #88

## Test plan
- [x] `npm test` 전체 통과 (176 tests)
- [ ] 수동: `updateWhileAnimating: true` 설정 후 애니메이션 중 타일 업데이트 확인
- [ ] 수동: `updateWhileInteracting: true` 설정 후 드래그 중 타일 업데이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)