### PR TITLE
feat(api): add background option to JP2LayerOptions (#90)

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -650,3 +650,39 @@ describe('zIndex option', () => {
   });
 });
 
+describe('background option', () => {
+  it('should accept background as a string', () => {
+    const opts: JP2LayerOptions = { background: 'rgba(0, 0, 0, 1)' };
+    expect(opts.background).toBe('rgba(0, 0, 0, 1)');
+  });
+
+  it('should accept background as a function', () => {
+    const fn = (zoom: number) => `rgba(0,0,0,${zoom})`;
+    const opts: JP2LayerOptions = { background: fn };
+    expect(opts.background).toBe(fn);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.background).toBeUndefined();
+  });
+
+  describe('resolveBackground logic (options?.background)', () => {
+    function resolveBackground(options?: JP2LayerOptions) {
+      return options?.background;
+    }
+
+    it('returns the value when background is set', () => {
+      expect(resolveBackground({ background: '#ff0000' })).toBe('#ff0000');
+    });
+
+    it('returns undefined when background is omitted', () => {
+      expect(resolveBackground({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveBackground(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -6,6 +6,7 @@ import { register } from 'ol/proj/proj4';
 import proj4 from 'proj4';
 import type Tile from 'ol/Tile';
 import ImageTile from 'ol/ImageTile';
+import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
@@ -115,6 +116,8 @@ export interface JP2LayerOptions {
   updateWhileAnimating?: boolean;
   /** 인터랙션 중 타일 업데이트 여부 (기본값: false) */
   updateWhileInteracting?: boolean;
+  /** 레이어 배경색. 타일이 없는 영역에 표시할 색상 (CSS 색상 문자열 또는 줌 레벨별 함수) */
+  background?: BackgroundColor;
 }
 
 export interface JP2LayerResult {
@@ -452,10 +455,11 @@ export async function createJP2TileLayer(
   const minResolution = options?.minResolution;
   const updateWhileAnimating = options?.updateWhileAnimating;
   const updateWhileInteracting = options?.updateWhileInteracting;
+  const background = options?.background;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `background` 옵션 추가 (`BackgroundColor` 타입: CSS 색상 문자열 또는 줌 레벨별 함수)
- `createJP2TileLayer`에서 OL `TileLayer`의 `background` 옵션으로 전달
- 단위 테스트 추가 (문자열/함수/undefined 케이스 및 resolve 로직)

closes #90

## Test plan
- [x] `npm test` 전체 182개 테스트 통과
- [ ] Reviewer: 코드 리뷰
- [ ] Tester: E2E 테스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)