### PR TITLE
docs(sprint-24): update CHANGELOG and README for background option (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 24
+
+### Added
+- **`JP2LayerOptions.background`**: 레이어 배경색 옵션 추가 (closes #90, PR #91)
+  - 타입: `BackgroundColor` (CSS 색상 문자열 또는 줌 레벨별 함수)
+  - 타일이 없는 영역에 표시할 배경색 지정
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `background` 옵션에 전달
+
+---
+
 ## [Unreleased] — Sprint 23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `minResolution` | `number` | - | 레이어가 표시되는 최소 해상도 (map units per pixel). 이 해상도 미만 시 숨김 |
 | `updateWhileAnimating` | `boolean` | `false` | 애니메이션 중 타일 업데이트 여부. `true` 시 패닝/줌 애니메이션 중에도 타일 업데이트 |
 | `updateWhileInteracting` | `boolean` | `false` | 인터랙션 중 타일 업데이트 여부. `true` 시 드래그/핀치 줌 중에도 타일 업데이트 |
+| `background` | `BackgroundColor` | - | 레이어 배경색. 타일이 없는 영역에 표시할 색상 (CSS 색상 문자열 또는 줌 레벨별 함수) |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 24 섹션 추가: `JP2LayerOptions.background` 옵션 문서화
- README API 테이블에 `background` 옵션 행 추가

closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)