### PR TITLE
feat(api): add useInterimTilesOnError option to JP2LayerOptions (#93)

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -686,3 +686,42 @@ describe('background option', () => {
   });
 });
 
+describe('useInterimTilesOnError option', () => {
+  it('should accept useInterimTilesOnError: true', () => {
+    const opts: JP2LayerOptions = { useInterimTilesOnError: true };
+    expect(opts.useInterimTilesOnError).toBe(true);
+  });
+
+  it('should accept useInterimTilesOnError: false', () => {
+    const opts: JP2LayerOptions = { useInterimTilesOnError: false };
+    expect(opts.useInterimTilesOnError).toBe(false);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.useInterimTilesOnError).toBeUndefined();
+  });
+
+  describe('resolveUseInterimTilesOnError logic (options?.useInterimTilesOnError)', () => {
+    function resolveUseInterimTilesOnError(options?: JP2LayerOptions): boolean | undefined {
+      return options?.useInterimTilesOnError;
+    }
+
+    it('returns true when set to true', () => {
+      expect(resolveUseInterimTilesOnError({ useInterimTilesOnError: true })).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(resolveUseInterimTilesOnError({ useInterimTilesOnError: false })).toBe(false);
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveUseInterimTilesOnError({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveUseInterimTilesOnError(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -118,6 +118,8 @@ export interface JP2LayerOptions {
   updateWhileInteracting?: boolean;
   /** 레이어 배경색. 타일이 없는 영역에 표시할 색상 (CSS 색상 문자열 또는 줌 레벨별 함수) */
   background?: BackgroundColor;
+  /** 타일 로드 오류 시 임시 타일(하위 해상도) 표시 여부 (기본값: true) */
+  useInterimTilesOnError?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -456,10 +458,11 @@ export async function createJP2TileLayer(
   const updateWhileAnimating = options?.updateWhileAnimating;
   const updateWhileInteracting = options?.updateWhileInteracting;
   const background = options?.background;
+  const useInterimTilesOnError = options?.useInterimTilesOnError;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions.useInterimTilesOnError?: boolean` 옵션 추가 (OL TileLayer 기본값: `true`)
- `createJP2TileLayer` 내 TileLayer 생성 시 해당 옵션 전달
- 단위 테스트 7개 추가 (총 189개 통과)

closes #93

## Test plan
- [x] `npm test` — 189 tests passed
- [ ] E2E: useInterimTilesOnError: false 설정 후 타일 에러 시 빈 타일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)