### PR TITLE
docs(sprint-25): update CHANGELOG and README for useInterimTilesOnError option (#93) (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 25
+
+### Added
+- **`JP2LayerOptions.useInterimTilesOnError`**: 타일 로드 오류 시 임시 타일(하위 해상도) 표시 여부 옵션 추가 (closes #93, PR #94)
+  - 타입: `boolean`, 기본값: `true` (OpenLayers TileLayer 기본값)
+  - `false`로 설정 시 타일 오류 발생 시 하위 해상도 타일 대신 빈 타일 표시
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `useInterimTilesOnError` 옵션에 전달
+
+---
+
 ## [Unreleased] — Sprint 24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `updateWhileAnimating` | `boolean` | `false` | 애니메이션 중 타일 업데이트 여부. `true` 시 패닝/줌 애니메이션 중에도 타일 업데이트 |
 | `updateWhileInteracting` | `boolean` | `false` | 인터랙션 중 타일 업데이트 여부. `true` 시 드래그/핀치 줌 중에도 타일 업데이트 |
 | `background` | `BackgroundColor` | - | 레이어 배경색. 타일이 없는 영역에 표시할 색상 (CSS 색상 문자열 또는 줌 레벨별 함수) |
+| `useInterimTilesOnError` | `boolean` | `true` | 타일 로드 오류 시 임시 타일(하위 해상도) 표시 여부. `false` 시 오류 타일 대신 빈 타일 표시 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 25 섹션 추가: `JP2LayerOptions.useInterimTilesOnError` 옵션 문서화
- README API 테이블에 `useInterimTilesOnError` 옵션 행 추가

closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)