### PR TITLE
feat(api): add properties option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -725,3 +725,38 @@ describe('useInterimTilesOnError option', () => {
   });
 });
 
+describe('properties option', () => {
+  it('should accept a properties object', () => {
+    const opts: JP2LayerOptions = { properties: { id: 'my-layer', name: 'test' } };
+    expect(opts.properties).toEqual({ id: 'my-layer', name: 'test' });
+  });
+
+  it('should accept an empty properties object', () => {
+    const opts: JP2LayerOptions = { properties: {} };
+    expect(opts.properties).toEqual({});
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.properties).toBeUndefined();
+  });
+
+  describe('resolveProperties logic (options?.properties)', () => {
+    function resolveProperties(options?: JP2LayerOptions): Record<string, unknown> | undefined {
+      return options?.properties;
+    }
+
+    it('returns the properties object when set', () => {
+      expect(resolveProperties({ properties: { id: 'layer-1' } })).toEqual({ id: 'layer-1' });
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveProperties({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveProperties(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -120,6 +120,8 @@ export interface JP2LayerOptions {
   background?: BackgroundColor;
   /** 타일 로드 오류 시 임시 타일(하위 해상도) 표시 여부 (기본값: true) */
   useInterimTilesOnError?: boolean;
+  /** 레이어에 설정할 임의의 키-값 속성. layer.get(key)로 조회 가능 */
+  properties?: Record<string, unknown>;
 }
 
 export interface JP2LayerResult {
@@ -459,10 +461,11 @@ export async function createJP2TileLayer(
   const updateWhileInteracting = options?.updateWhileInteracting;
   const background = options?.background;
   const useInterimTilesOnError = options?.useInterimTilesOnError;
+  const properties = options?.properties;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `properties?: Record<string, unknown>` 옵션 추가
- `createJP2TileLayer`에서 `TileLayer` 생성 시 `properties`를 전달
- 단위 테스트 추가 (6개 케이스)

closes #96

## Test plan
- [x] `npm test` 통과 (195 tests passed)
- [ ] Reviewer: 코드 변경 확인
- [ ] Tester: E2E 테스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)