### PR TITLE
feat(api): add renderBuffer option to JP2LayerOptions (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 27
+
+### Added
+- **`JP2LayerOptions.renderBuffer`**: 뷰포트 경계 바깥으로 미리 렌더링할 픽셀 수 옵션 추가 (closes #99)
+  - 타입: `number`, 기본값: OL 기본값 `100`
+  - 빠른 패닝 시 타일 공백을 줄이기 위해 렌더 버퍼 크기를 조정 가능
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `renderBuffer` 옵션에 전달
+
+---
+
 ## [Unreleased] — Sprint 25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `updateWhileInteracting` | `boolean` | `false` | 인터랙션 중 타일 업데이트 여부. `true` 시 드래그/핀치 줌 중에도 타일 업데이트 |
 | `background` | `BackgroundColor` | - | 레이어 배경색. 타일이 없는 영역에 표시할 색상 (CSS 색상 문자열 또는 줌 레벨별 함수) |
 | `useInterimTilesOnError` | `boolean` | `true` | 타일 로드 오류 시 임시 타일(하위 해상도) 표시 여부. `false` 시 오류 타일 대신 빈 타일 표시 |
+| `renderBuffer` | `number` | `100` | 뷰포트 경계 바깥으로 미리 렌더링할 픽셀 수. 빠른 패닝 시 타일 공백을 줄인다 |
 
 #### 반환값 (`JP2LayerResult`)
 

--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -760,3 +760,38 @@ describe('properties option', () => {
   });
 });
 
+describe('renderBuffer option', () => {
+  it('should accept a numeric renderBuffer', () => {
+    const opts: JP2LayerOptions = { renderBuffer: 200 };
+    expect(opts.renderBuffer).toBe(200);
+  });
+
+  it('should accept renderBuffer: 0', () => {
+    const opts: JP2LayerOptions = { renderBuffer: 0 };
+    expect(opts.renderBuffer).toBe(0);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.renderBuffer).toBeUndefined();
+  });
+
+  describe('resolveRenderBuffer logic (options?.renderBuffer)', () => {
+    function resolveRenderBuffer(options?: JP2LayerOptions): number | undefined {
+      return options?.renderBuffer;
+    }
+
+    it('returns the value when renderBuffer is set', () => {
+      expect(resolveRenderBuffer({ renderBuffer: 200 })).toBe(200);
+    });
+
+    it('returns undefined when renderBuffer is omitted (OL uses default 100)', () => {
+      expect(resolveRenderBuffer({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveRenderBuffer(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -122,6 +122,8 @@ export interface JP2LayerOptions {
   useInterimTilesOnError?: boolean;
   /** 레이어에 설정할 임의의 키-값 속성. layer.get(key)로 조회 가능 */
   properties?: Record<string, unknown>;
+  /** 뷰포트 경계 바깥으로 미리 렌더링할 픽셀 수 (기본값: OL 기본값 100). 빠른 패닝 시 타일 공백을 줄인다 */
+  renderBuffer?: number;
 }
 
 export interface JP2LayerResult {
@@ -462,10 +464,11 @@ export async function createJP2TileLayer(
   const background = options?.background;
   const useInterimTilesOnError = options?.useInterimTilesOnError;
   const properties = options?.properties;
+  const renderBuffer = options?.renderBuffer;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties, renderBuffer })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties, renderBuffer });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `renderBuffer?: number` 필드 추가
- `createJP2TileLayer` 내부 `TileLayer` 생성 시 `renderBuffer` 전달
- 단위 테스트 추가 (source.test.ts)
- CHANGELOG, README 업데이트

closes #99

## Test plan
- [x] `npm test` 전체 통과 (201 tests)
- [ ] `renderBuffer: 200` 지정 시 TileLayer에 정확히 전달되는지 확인
- [ ] 미지정 시 OL 기본값(100) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)