### PR TITLE
feat(api): add interpolate option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -760,6 +760,45 @@ describe('properties option', () => {
   });
 });
 
+describe('interpolate option', () => {
+  it('should accept interpolate: true', () => {
+    const opts: JP2LayerOptions = { interpolate: true };
+    expect(opts.interpolate).toBe(true);
+  });
+
+  it('should accept interpolate: false', () => {
+    const opts: JP2LayerOptions = { interpolate: false };
+    expect(opts.interpolate).toBe(false);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.interpolate).toBeUndefined();
+  });
+
+  describe('resolveInterpolate logic (options?.interpolate)', () => {
+    function resolveInterpolate(options?: JP2LayerOptions): boolean | undefined {
+      return options?.interpolate;
+    }
+
+    it('returns true when set to true', () => {
+      expect(resolveInterpolate({ interpolate: true })).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(resolveInterpolate({ interpolate: false })).toBe(false);
+    });
+
+    it('returns undefined when omitted (OL defaults to true)', () => {
+      expect(resolveInterpolate({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveInterpolate(undefined)).toBeUndefined();
+    });
+  });
+});
+
 describe('renderBuffer option', () => {
   it('should accept a numeric renderBuffer', () => {
     const opts: JP2LayerOptions = { renderBuffer: 200 };

--- a/src/source.ts
+++ b/src/source.ts
@@ -124,6 +124,8 @@ export interface JP2LayerOptions {
   properties?: Record<string, unknown>;
   /** 뷰포트 경계 바깥으로 미리 렌더링할 픽셀 수 (기본값: OL 기본값 100). 빠른 패닝 시 타일 공백을 줄인다 */
   renderBuffer?: number;
+  /** 타일 렌더링 시 보간(interpolation) 방식 제어 (기본값: true). false로 설정하면 nearest-neighbor 보간 적용 */
+  interpolate?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -465,10 +467,11 @@ export async function createJP2TileLayer(
   const useInterimTilesOnError = options?.useInterimTilesOnError;
   const properties = options?.properties;
   const renderBuffer = options?.renderBuffer;
+  const interpolate = options?.interpolate;
 
   const layer = geoInfo
-    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties, renderBuffer })
-    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties, renderBuffer });
+    ? new TileLayer({ source, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties, renderBuffer, interpolate })
+    : new TileLayer({ source, extent, opacity, visible, zIndex, preload, className, minZoom, maxZoom, maxResolution, minResolution, updateWhileAnimating, updateWhileInteracting, background, useInterimTilesOnError, properties, renderBuffer, interpolate });
 
   const destroy = () => {
     provider.destroy();


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `interpolate?: boolean` 필드 추가
- `createJP2TileLayer`에서 OL TileLayer에 `interpolate` 옵션 전달
- 단위 테스트 7개 추가 (타입, resolve 로직)

closes #101

## Test plan
- [x] `npm test` 통과 (208 tests passed)
- [ ] `interpolate: false` 설정 시 nearest-neighbor 렌더링 확인
- [ ] 미지정 시 OL 기본값(true, bilinear) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)