### PR TITLE
docs(sprint-28): update CHANGELOG and README for interpolate option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 28
+
+### Added
+- **`JP2LayerOptions.interpolate`**: 타일 렌더링 시 보간 방식을 제어하는 옵션 추가 (closes #101, PR #102)
+  - 타입: `boolean`, 기본값: `true` (OpenLayers TileLayer 기본값, bilinear 보간)
+  - `false`로 설정 시 nearest-neighbor 보간 적용 — 픽셀 아트, 위성 이미지 등 선명한 픽셀 경계가 필요한 경우에 유용
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileLayer`의 `interpolate` 옵션에 전달
+
+---
+
 ## [Unreleased] — Sprint 27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `useInterimTilesOnError` | `boolean` | `true` | 타일 로드 오류 시 임시 타일(하위 해상도) 표시 여부. `false` 시 오류 타일 대신 빈 타일 표시 |
 | `properties` | `Record<string, unknown>` | - | 레이어에 설정할 임의의 키-값 속성. `layer.get(key)`로 조회 가능 |
 | `renderBuffer` | `number` | `100` | 뷰포트 경계 바깥으로 미리 렌더링할 픽셀 수. 빠른 패닝 시 타일 공백을 줄인다 |
+| `interpolate` | `boolean` | `true` | 타일 렌더링 시 보간(interpolation) 방식 제어. `false` 설정 시 nearest-neighbor 보간 적용 (픽셀 선명도 유지) |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 28 섹션 추가 (`interpolate` 옵션 문서화)
- README `JP2LayerOptions` 옵션 테이블에 `interpolate` 항목 추가

closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)