### PR TITLE
feat(api): add transition option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -859,6 +859,45 @@ describe('maxConcurrency option', () => {
   });
 });
 
+describe('transition option', () => {
+  it('should accept a numeric transition', () => {
+    const opts: JP2LayerOptions = { transition: 500 };
+    expect(opts.transition).toBe(500);
+  });
+
+  it('should accept transition: 0 (no fade-in)', () => {
+    const opts: JP2LayerOptions = { transition: 0 };
+    expect(opts.transition).toBe(0);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.transition).toBeUndefined();
+  });
+
+  describe('resolveTransition logic (options?.transition)', () => {
+    function resolveTransition(options?: JP2LayerOptions): number | undefined {
+      return options?.transition;
+    }
+
+    it('returns the value when transition is set', () => {
+      expect(resolveTransition({ transition: 300 })).toBe(300);
+    });
+
+    it('returns 0 when transition is 0', () => {
+      expect(resolveTransition({ transition: 0 })).toBe(0);
+    });
+
+    it('returns undefined when transition is omitted (OL defaults to 250)', () => {
+      expect(resolveTransition({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveTransition(undefined)).toBeUndefined();
+    });
+  });
+});
+
 describe('renderBuffer option', () => {
   it('should accept a numeric renderBuffer', () => {
     const opts: JP2LayerOptions = { renderBuffer: 200 };

--- a/src/source.ts
+++ b/src/source.ts
@@ -130,6 +130,8 @@ export interface JP2LayerOptions {
   cacheTTL?: number;
   /** 디코딩 WebWorker 풀 크기. URL 문자열로 호출 시 RangeTileProvider에 전달 (기본값: WorkerPool 기본값) */
   maxConcurrency?: number;
+  /** 타일 페이드인 애니메이션 지속 시간 (ms, 기본값: OL 기본값 250). 0으로 설정하면 즉시 표시 */
+  transition?: number;
 }
 
 export interface JP2LayerResult {
@@ -274,10 +276,12 @@ export async function createJP2TileLayer(
   };
 
   const bands = options?.bands;
+  const transition = options?.transition;
   const source = new TileImage({
     projection,
     tileGrid,
     attributions: options?.attributions,
+    transition,
     tileUrlFunction: (tileCoord) => {
       const [z, x, y] = tileCoord;
       const subtilesPerAxis = tileWidth / DISPLAY_TILE_SIZE / pixelResolutions[z];


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `transition?: number` 옵션 추가
- OL `TileImage` 소스의 타일 페이드인 애니메이션 지속 시간 제어 (기본값: OL 250ms, 0으로 즉시 표시)
- 단위 테스트 7개 추가

closes #109

## Test plan
- [x] `npm test` 전체 통과 (225 tests)
- [ ] 데모에서 `transition: 0` 설정 시 즉시 표시 확인
- [ ] `transition: 1000` 설정 시 느린 페이드인 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)