### PR TITLE
docs(sprint-31): update CHANGELOG and README for transition option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased] — Sprint 31
+
+### Added
+- **`JP2LayerOptions.transition`**: 타일 페이드인 애니메이션 지속 시간 옵션 추가 (closes #109, PR #110)
+  - 타입: `number` (밀리초), 기본값: OL 기본값 `250`
+  - `0`으로 설정 시 애니메이션 없이 즉시 표시
+  - `createJP2TileLayer` 내부에서 OpenLayers `TileImage` 소스의 `transition` 옵션에 전달
+
+---
+
 ## [Unreleased] — Sprint 30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `interpolate` | `boolean` | `true` | 타일 렌더링 시 보간(interpolation) 방식 제어. `false` 설정 시 nearest-neighbor 보간 적용 (픽셀 선명도 유지) |
 | `cacheTTL` | `number` | `86400000` (24시간) | IndexedDB 타일 인덱스 캐시 TTL (밀리초). URL 문자열로 호출 시 `RangeTileProvider`에 전달 |
 | `maxConcurrency` | `number` | WorkerPool 기본값 | 디코딩 WebWorker 풀 크기. URL 문자열로 호출 시 `RangeTileProvider`에 전달 |
+| `transition` | `number` | `250` | 타일 페이드인 애니메이션 지속 시간 (ms). `0`으로 설정 시 애니메이션 없이 즉시 표시 |
 | `cacheSize` | `number` | `512` | 레이어 내부 인메모리 타일 캐시 크기. 대용량 JP2나 고해상도 뷰에서 재디코딩을 줄이려면 값을 늘린다 |
 
 #### 반환값 (`JP2LayerResult`)


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 31 항목 추가: `JP2LayerOptions.transition` 옵션 (closes #109, PR #110)
- README API 옵션 테이블에 `transition` 옵션 추가

## Test plan
- [ ] CHANGELOG Sprint 31 항목 내용 확인
- [ ] README 옵션 테이블에 `transition` 행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)