### PR TITLE
feat(api): add cacheSize option to JP2LayerOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 32
+
+### Added
+- **`JP2LayerOptions.cacheSize`**: 레이어 내부 인메모리 타일 캐시 크기를 제어하는 옵션 추가 (closes #112)
+  - 타입: `number`, 기본값: OL 기본값 `512`
+  - `TileImage` 소스의 `cacheSize` 옵션에 전달
+  - 대용량 JP2 파일이나 고해상도 뷰에서 캐시 부족으로 인한 불필요한 재디코딩 방지
+
+---
+
 ## [Unreleased] — Sprint 30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `interpolate` | `boolean` | `true` | 타일 렌더링 시 보간(interpolation) 방식 제어. `false` 설정 시 nearest-neighbor 보간 적용 (픽셀 선명도 유지) |
 | `cacheTTL` | `number` | `86400000` (24시간) | IndexedDB 타일 인덱스 캐시 TTL (밀리초). URL 문자열로 호출 시 `RangeTileProvider`에 전달 |
 | `maxConcurrency` | `number` | WorkerPool 기본값 | 디코딩 WebWorker 풀 크기. URL 문자열로 호출 시 `RangeTileProvider`에 전달 |
+| `cacheSize` | `number` | `512` | 레이어 내부 인메모리 타일 캐시 크기. 대용량 JP2나 고해상도 뷰에서 재디코딩을 줄이려면 값을 늘린다 |
 
 #### 반환값 (`JP2LayerResult`)
 

--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -933,3 +933,33 @@ describe('renderBuffer option', () => {
   });
 });
 
+describe('cacheSize option', () => {
+  it('should accept a numeric cacheSize', () => {
+    const opts: JP2LayerOptions = { cacheSize: 1024 };
+    expect(opts.cacheSize).toBe(1024);
+  });
+
+  it('should be optional (undefined when not specified, OL defaults to 512)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.cacheSize).toBeUndefined();
+  });
+
+  describe('resolveCacheSize logic (options?.cacheSize)', () => {
+    function resolveCacheSize(options?: JP2LayerOptions): number | undefined {
+      return options?.cacheSize;
+    }
+
+    it('returns the value when cacheSize is set', () => {
+      expect(resolveCacheSize({ cacheSize: 2048 })).toBe(2048);
+    });
+
+    it('returns undefined when cacheSize is omitted (OL defaults to 512)', () => {
+      expect(resolveCacheSize({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveCacheSize(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -132,6 +132,8 @@ export interface JP2LayerOptions {
   maxConcurrency?: number;
   /** 타일 페이드인 애니메이션 지속 시간 (ms, 기본값: OL 기본값 250). 0으로 설정하면 즉시 표시 */
   transition?: number;
+  /** 레이어 내부 인메모리 타일 캐시 크기 (기본값: OL 기본값 512) */
+  cacheSize?: number;
 }
 
 export interface JP2LayerResult {
@@ -277,11 +279,13 @@ export async function createJP2TileLayer(
 
   const bands = options?.bands;
   const transition = options?.transition;
+  const cacheSize = options?.cacheSize;
   const source = new TileImage({
     projection,
     tileGrid,
     attributions: options?.attributions,
     transition,
+    cacheSize,
     tileUrlFunction: (tileCoord) => {
       const [z, x, y] = tileCoord;
       const subtilesPerAxis = tileWidth / DISPLAY_TILE_SIZE / pixelResolutions[z];


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `cacheSize?: number` 옵션 추가
- `TileImage` 소스의 `cacheSize`에 전달하여 인메모리 타일 캐시 크기 제어
- 단위 테스트, CHANGELOG, README 업데이트

closes #112

## Test plan
- [x] `npm test` 통과 (230 tests passed)
- [ ] 대용량 JP2 파일로 cacheSize 값 변경 시 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)