### PR TITLE
feat(api): add wrapX option to JP2LayerOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 33
+
+### Added
+- **`JP2LayerOptions.wrapX`**: 타일 소스의 경도 방향(X축) 반복 렌더링을 제어하는 옵션 추가 (closes #115)
+  - 타입: `boolean`, 기본값: OL 기본값 `true`
+  - `TileImage` 소스의 `wrapX` 옵션에 전달
+  - `false`로 설정하면 원본 범위 외부에서 JP2 타일이 반복 표시되지 않음
+
+---
+
 ## [Unreleased] — Sprint 32
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `maxConcurrency` | `number` | WorkerPool 기본값 | 디코딩 WebWorker 풀 크기. URL 문자열로 호출 시 `RangeTileProvider`에 전달 |
 | `transition` | `number` | `250` | 타일 페이드인 애니메이션 지속 시간 (ms). `0`으로 설정 시 애니메이션 없이 즉시 표시 |
 | `cacheSize` | `number` | `512` | 레이어 내부 인메모리 타일 캐시 크기. 대용량 JP2나 고해상도 뷰에서 재디코딩을 줄이려면 값을 늘린다 |
+| `wrapX` | `boolean` | `true` | 타일 소스의 경도 방향(X축) 반복 렌더링 여부. `false`로 설정하면 원본 범위 외부에서 타일이 반복 표시되지 않음 |
 
 #### 반환값 (`JP2LayerResult`)
 

--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -963,3 +963,42 @@ describe('cacheSize option', () => {
   });
 });
 
+describe('JP2LayerOptions — wrapX', () => {
+  it('should accept wrapX: false', () => {
+    const opts: JP2LayerOptions = { wrapX: false };
+    expect(opts.wrapX).toBe(false);
+  });
+
+  it('should accept wrapX: true', () => {
+    const opts: JP2LayerOptions = { wrapX: true };
+    expect(opts.wrapX).toBe(true);
+  });
+
+  it('should be optional (undefined when not specified, OL defaults to true)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.wrapX).toBeUndefined();
+  });
+
+  describe('resolveWrapX logic (options?.wrapX)', () => {
+    function resolveWrapX(options?: JP2LayerOptions): boolean | undefined {
+      return options?.wrapX;
+    }
+
+    it('returns false when wrapX is false', () => {
+      expect(resolveWrapX({ wrapX: false })).toBe(false);
+    });
+
+    it('returns true when wrapX is true', () => {
+      expect(resolveWrapX({ wrapX: true })).toBe(true);
+    });
+
+    it('returns undefined when wrapX is omitted (OL defaults to true)', () => {
+      expect(resolveWrapX({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveWrapX(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -134,6 +134,8 @@ export interface JP2LayerOptions {
   transition?: number;
   /** 레이어 내부 인메모리 타일 캐시 크기 (기본값: OL 기본값 512) */
   cacheSize?: number;
+  /** 타일 소스의 경도 방향(X축) 반복 렌더링 여부 (기본값: OL 기본값 true). false로 설정하면 원본 범위 외부에서 타일이 반복 표시되지 않음 */
+  wrapX?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -280,12 +282,14 @@ export async function createJP2TileLayer(
   const bands = options?.bands;
   const transition = options?.transition;
   const cacheSize = options?.cacheSize;
+  const wrapX = options?.wrapX;
   const source = new TileImage({
     projection,
     tileGrid,
     attributions: options?.attributions,
     transition,
     cacheSize,
+    wrapX,
     tileUrlFunction: (tileCoord) => {
       const [z, x, y] = tileCoord;
       const subtilesPerAxis = tileWidth / DISPLAY_TILE_SIZE / pixelResolutions[z];


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `wrapX?: boolean` 옵션 추가
- `TileImage` 소스 생성 시 `wrapX` 옵션 전달
- 단위 테스트 7개 추가 (총 237개 통과)
- CHANGELOG, README 업데이트

closes #115

## Test plan
- [x] `npm test` 전체 통과 (237 tests)
- [ ] E2E: `wrapX: false` 설정 시 범위 외부에 타일 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)