### PR TITLE
docs(api): document extent option for JP2LayerOptions (sprint 34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 34
+
+### Added
+- **`JP2LayerOptions.extent`**: 레이어가 렌더링될 지리 범위를 제한하는 옵션 추가 (closes #117, PR #118)
+  - 타입: `[minX, minY, maxX, maxY]`, 기본값: JP2 파일에서 계산된 범위 (Geographic mode) 또는 전체 픽셀 범위 (Pixel mode)
+  - 지정 시 해당 범위 내에서만 타일이 렌더링되며, 범위 바깥의 타일은 표시되지 않음
+  - Geographic mode(지리 정보 포함 JP2)에서는 JP2에서 계산된 extent를 대체하여 `TileLayer`의 `extent`로 사용
+  - Pixel mode(지리 정보 없는 JP2)에서도 `TileLayer`의 `extent`를 명시적으로 제한 가능
+  - 좌표는 레이어가 사용하는 투영계(projection) 단위를 따름 (예: EPSG:4326이면 경위도 도(degree))
+
+---
+
 ## [Unreleased] — Sprint 33
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `transition` | `number` | `250` | 타일 페이드인 애니메이션 지속 시간 (ms). `0`으로 설정 시 애니메이션 없이 즉시 표시 |
 | `cacheSize` | `number` | `512` | 레이어 내부 인메모리 타일 캐시 크기. 대용량 JP2나 고해상도 뷰에서 재디코딩을 줄이려면 값을 늘린다 |
 | `wrapX` | `boolean` | `true` | 타일 소스의 경도 방향(X축) 반복 렌더링 여부. `false`로 설정하면 원본 범위 외부에서 타일이 반복 표시되지 않음 |
+| `extent` | `[number, number, number, number]` | JP2 파일 범위 | 레이어가 렌더링될 지리 범위 `[minX, minY, maxX, maxY]`. 지정 시 해당 범위 내에서만 타일이 렌더링됨. 좌표는 레이어의 투영계 단위를 따름 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG.md에 Sprint 34 항목 추가: `JP2LayerOptions.extent` 옵션 문서화
- README.md API 옵션 테이블에 `extent` 옵션 행 추가

## 변경 내용
- `extent`: 레이어가 렌더링될 지리 범위 `[minX, minY, maxX, maxY]` 옵션
  - closes #117 (PR #118)에서 구현된 기능 문서화

## Test plan
- [ ] CHANGELOG, README 링크 및 내용 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)