### PR TITLE
feat(api): add crossOrigin option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -993,6 +993,50 @@ describe('JP2LayerOptions — extent', () => {
   });
 });
 
+describe('JP2LayerOptions — crossOrigin', () => {
+  it('should accept crossOrigin: "anonymous"', () => {
+    const opts: JP2LayerOptions = { crossOrigin: 'anonymous' };
+    expect(opts.crossOrigin).toBe('anonymous');
+  });
+
+  it('should accept crossOrigin: "use-credentials"', () => {
+    const opts: JP2LayerOptions = { crossOrigin: 'use-credentials' };
+    expect(opts.crossOrigin).toBe('use-credentials');
+  });
+
+  it('should accept crossOrigin: null', () => {
+    const opts: JP2LayerOptions = { crossOrigin: null };
+    expect(opts.crossOrigin).toBeNull();
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.crossOrigin).toBeUndefined();
+  });
+
+  describe('resolveCrossOrigin logic (options?.crossOrigin)', () => {
+    function resolveCrossOrigin(options?: JP2LayerOptions): string | null | undefined {
+      return options?.crossOrigin;
+    }
+
+    it('returns "anonymous" when set', () => {
+      expect(resolveCrossOrigin({ crossOrigin: 'anonymous' })).toBe('anonymous');
+    });
+
+    it('returns null when set to null', () => {
+      expect(resolveCrossOrigin({ crossOrigin: null })).toBeNull();
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveCrossOrigin({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveCrossOrigin(undefined)).toBeUndefined();
+    });
+  });
+});
+
 describe('JP2LayerOptions — wrapX', () => {
   it('should accept wrapX: false', () => {
     const opts: JP2LayerOptions = { wrapX: false };

--- a/src/source.ts
+++ b/src/source.ts
@@ -136,6 +136,8 @@ export interface JP2LayerOptions {
   cacheSize?: number;
   /** 타일 소스의 경도 방향(X축) 반복 렌더링 여부 (기본값: OL 기본값 true). false로 설정하면 원본 범위 외부에서 타일이 반복 표시되지 않음 */
   wrapX?: boolean;
+  /** CORS 크로스오리진 설정. 다른 오리진에서 JP2 파일을 서빙할 때 canvas 픽셀 접근을 위해 필요 (예: 'anonymous', 'use-credentials') */
+  crossOrigin?: string | null;
   /**
    * 레이어가 렌더링될 지리 범위 `[minX, minY, maxX, maxY]`.
    * 지정 시 해당 범위 내에서만 타일이 렌더링되며, 범위 바깥의 타일은 표시되지 않는다.
@@ -297,6 +299,7 @@ export async function createJP2TileLayer(
   const transition = options?.transition;
   const cacheSize = options?.cacheSize;
   const wrapX = options?.wrapX;
+  const crossOrigin = options?.crossOrigin;
   const source = new TileImage({
     projection,
     tileGrid,
@@ -304,6 +307,7 @@ export async function createJP2TileLayer(
     transition,
     cacheSize,
     wrapX,
+    crossOrigin,
     tileUrlFunction: (tileCoord) => {
       const [z, x, y] = tileCoord;
       const subtilesPerAxis = tileWidth / DISPLAY_TILE_SIZE / pixelResolutions[z];


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `crossOrigin?: string | null` 필드 추가
- `TileImage` 소스 생성 시 `crossOrigin` 옵션 전달
- JSDoc 주석 및 단위 테스트 추가

closes #121

## Test plan
- [x] `npm test` 통과 (250 tests passed)
- [x] 타입 테스트: `crossOrigin: 'anonymous'`, `'use-credentials'`, `null` 모두 수용
- [x] 옵션 미지정 시 `undefined` (OL 기본 동작)

🤖 Generated with [Claude Code](https://claude.com/claude-code)