### PR TITLE
feat(api): add tilePixelRatio option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -1076,3 +1076,42 @@ describe('JP2LayerOptions — wrapX', () => {
   });
 });
 
+describe('JP2LayerOptions — tilePixelRatio', () => {
+  it('should accept tilePixelRatio: 2 (HiDPI)', () => {
+    const opts: JP2LayerOptions = { tilePixelRatio: 2 };
+    expect(opts.tilePixelRatio).toBe(2);
+  });
+
+  it('should accept tilePixelRatio: 1 (default)', () => {
+    const opts: JP2LayerOptions = { tilePixelRatio: 1 };
+    expect(opts.tilePixelRatio).toBe(1);
+  });
+
+  it('should be optional (undefined when not specified, OL defaults to 1)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.tilePixelRatio).toBeUndefined();
+  });
+
+  describe('resolveTilePixelRatio logic (options?.tilePixelRatio)', () => {
+    function resolveTilePixelRatio(options?: JP2LayerOptions): number | undefined {
+      return options?.tilePixelRatio;
+    }
+
+    it('returns 2 when tilePixelRatio is 2', () => {
+      expect(resolveTilePixelRatio({ tilePixelRatio: 2 })).toBe(2);
+    });
+
+    it('returns 1 when tilePixelRatio is 1', () => {
+      expect(resolveTilePixelRatio({ tilePixelRatio: 1 })).toBe(1);
+    });
+
+    it('returns undefined when tilePixelRatio is omitted (OL defaults to 1)', () => {
+      expect(resolveTilePixelRatio({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveTilePixelRatio(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -152,6 +152,8 @@ export interface JP2LayerOptions {
    * createJP2TileLayer('map.jp2', { extent: [124, 33, 132, 39] });
    */
   extent?: [number, number, number, number];
+  /** 타일 이미지 픽셀과 CSS 픽셀의 비율 (기본값: OL 기본값 1). HiDPI/Retina 디스플레이에서 고해상도 타일을 렌더링하려면 2로 설정 */
+  tilePixelRatio?: number;
 }
 
 export interface JP2LayerResult {
@@ -300,6 +302,7 @@ export async function createJP2TileLayer(
   const cacheSize = options?.cacheSize;
   const wrapX = options?.wrapX;
   const crossOrigin = options?.crossOrigin;
+  const tilePixelRatio = options?.tilePixelRatio;
   const source = new TileImage({
     projection,
     tileGrid,
@@ -308,6 +311,7 @@ export async function createJP2TileLayer(
     cacheSize,
     wrapX,
     crossOrigin,
+    tilePixelRatio,
     tileUrlFunction: (tileCoord) => {
       const [z, x, y] = tileCoord;
       const subtilesPerAxis = tileWidth / DISPLAY_TILE_SIZE / pixelResolutions[z];


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `tilePixelRatio?: number` 옵션 추가
- `TileImage` 소스 생성 시 `tilePixelRatio` 옵션 전달
- 단위 테스트 추가 (타입 검증 + resolve 로직)

closes #124

## Test plan
- [x] `npm test` 전체 통과 (257 tests)
- [ ] HiDPI 환경에서 `tilePixelRatio: 2` 설정 후 타일 선명도 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)