### PR TITLE
feat(api): add attributionsCollapsible option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -157,6 +157,28 @@ describe('attributions option', () => {
   });
 });
 
+describe('attributionsCollapsible option', () => {
+  it('should accept a boolean value (false)', () => {
+    const opts: JP2LayerOptions = {
+      attributions: '© Test',
+      attributionsCollapsible: false,
+    };
+    expect(opts.attributionsCollapsible).toBe(false);
+  });
+
+  it('should accept a boolean value (true)', () => {
+    const opts: JP2LayerOptions = {
+      attributionsCollapsible: true,
+    };
+    expect(opts.attributionsCollapsible).toBe(true);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.attributionsCollapsible).toBeUndefined();
+  });
+});
+
 describe('bands option', () => {
   it('should accept a 3-element tuple of band indices', () => {
     const opts: JP2LayerOptions = {

--- a/src/source.ts
+++ b/src/source.ts
@@ -94,6 +94,8 @@ export interface JP2LayerOptions {
   onTileLoadStart?: (info: { col: number; row: number; decodeLevel: number }) => void;
   /** OpenLayers 소스에 표시할 저작권/출처 정보 */
   attributions?: string | string[];
+  /** 저작권 표기 패널의 접기 버튼 표시 여부 (기본값: true, 접기 가능) */
+  attributionsCollapsible?: boolean;
   /** 다중 채널 이미지에서 RGB에 매핑할 밴드 인덱스 (0-based). 예: [3, 2, 1] */
   bands?: [r: number, g: number, b: number];
   /** 레이어 초기 가시성 (기본값: true) */
@@ -307,6 +309,7 @@ export async function createJP2TileLayer(
     projection,
     tileGrid,
     attributions: options?.attributions,
+    attributionsCollapsible: options?.attributionsCollapsible,
     transition,
     cacheSize,
     wrapX,


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `attributionsCollapsible?: boolean` 옵션 추가
- OL TileImage 소스 생성 시 해당 옵션을 전달하도록 구현
- 단위 테스트 3건 추가 (true/false/undefined)

closes #126

## Test plan
- [x] `npm test` 전체 통과 (260 tests)
- [ ] `attributionsCollapsible: false` 설정 시 접기 버튼 미표시 확인
- [ ] 미지정 시 기본 동작(접기 가능) 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)