### PR TITLE
feat(api): add reprojectionErrorThreshold and opaque options (#129, #130)

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -1137,3 +1137,81 @@ describe('JP2LayerOptions — tilePixelRatio', () => {
   });
 });
 
+describe('JP2LayerOptions — reprojectionErrorThreshold', () => {
+  it('should accept reprojectionErrorThreshold: 0.5 (default)', () => {
+    const opts: JP2LayerOptions = { reprojectionErrorThreshold: 0.5 };
+    expect(opts.reprojectionErrorThreshold).toBe(0.5);
+  });
+
+  it('should accept reprojectionErrorThreshold: 0.1 (high precision)', () => {
+    const opts: JP2LayerOptions = { reprojectionErrorThreshold: 0.1 };
+    expect(opts.reprojectionErrorThreshold).toBe(0.1);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.reprojectionErrorThreshold).toBeUndefined();
+  });
+
+  describe('resolveReprojectionErrorThreshold logic', () => {
+    function resolveReprojectionErrorThreshold(options?: JP2LayerOptions): number | undefined {
+      return options?.reprojectionErrorThreshold;
+    }
+
+    it('returns 0.5 when set to 0.5', () => {
+      expect(resolveReprojectionErrorThreshold({ reprojectionErrorThreshold: 0.5 })).toBe(0.5);
+    });
+
+    it('returns 0.1 when set to 0.1', () => {
+      expect(resolveReprojectionErrorThreshold({ reprojectionErrorThreshold: 0.1 })).toBe(0.1);
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveReprojectionErrorThreshold({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveReprojectionErrorThreshold(undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('JP2LayerOptions — opaque', () => {
+  it('should accept opaque: true', () => {
+    const opts: JP2LayerOptions = { opaque: true };
+    expect(opts.opaque).toBe(true);
+  });
+
+  it('should accept opaque: false', () => {
+    const opts: JP2LayerOptions = { opaque: false };
+    expect(opts.opaque).toBe(false);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.opaque).toBeUndefined();
+  });
+
+  describe('resolveOpaque logic', () => {
+    function resolveOpaque(options?: JP2LayerOptions): boolean | undefined {
+      return options?.opaque;
+    }
+
+    it('returns true when set to true', () => {
+      expect(resolveOpaque({ opaque: true })).toBe(true);
+    });
+
+    it('returns false when set to false', () => {
+      expect(resolveOpaque({ opaque: false })).toBe(false);
+    });
+
+    it('returns undefined when omitted', () => {
+      expect(resolveOpaque({})).toBeUndefined();
+    });
+
+    it('returns undefined when options is undefined', () => {
+      expect(resolveOpaque(undefined)).toBeUndefined();
+    });
+  });
+});
+

--- a/src/source.ts
+++ b/src/source.ts
@@ -156,6 +156,10 @@ export interface JP2LayerOptions {
   extent?: [number, number, number, number];
   /** 타일 이미지 픽셀과 CSS 픽셀의 비율 (기본값: OL 기본값 1). HiDPI/Retina 디스플레이에서 고해상도 타일을 렌더링하려면 2로 설정 */
   tilePixelRatio?: number;
+  /** 타일 재투영(reprojection) 시 허용되는 최대 픽셀 오차 임계값 (기본값: OL 기본값 0.5). 낮을수록 정확하지만 성능 비용 증가 */
+  reprojectionErrorThreshold?: number;
+  /** 타일 소스가 불투명(opaque)함을 렌더러에 알리는 힌트 (기본값: OL 기본값 false). true로 설정하면 하위 레이어 렌더링 생략 최적화 가능 */
+  opaque?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -305,6 +309,8 @@ export async function createJP2TileLayer(
   const wrapX = options?.wrapX;
   const crossOrigin = options?.crossOrigin;
   const tilePixelRatio = options?.tilePixelRatio;
+  const reprojectionErrorThreshold = options?.reprojectionErrorThreshold;
+  const opaque = options?.opaque;
   const source = new TileImage({
     projection,
     tileGrid,
@@ -315,6 +321,8 @@ export async function createJP2TileLayer(
     wrapX,
     crossOrigin,
     tilePixelRatio,
+    reprojectionErrorThreshold,
+    opaque,
     tileUrlFunction: (tileCoord) => {
       const [z, x, y] = tileCoord;
       const subtilesPerAxis = tileWidth / DISPLAY_TILE_SIZE / pixelResolutions[z];


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `reprojectionErrorThreshold` 옵션 추가 (재투영 오차 허용 임계값, closes #129)
- `JP2LayerOptions`에 `opaque` 옵션 추가 (타일 소스 불투명도 힌트, closes #130)
- 두 옵션 모두 `TileImage` 소스 생성 시 전달되도록 구현

## Test plan
- [x] 단위 테스트 추가 (reprojectionErrorThreshold, opaque 각각 타입 검증 및 resolve 로직)
- [x] 기존 274개 테스트 모두 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)