### PR TITLE
feat(api): add tileSize option to JP2LayerOptions

### DIFF
--- a/src/source.test.ts
+++ b/src/source.test.ts
@@ -1176,6 +1176,40 @@ describe('JP2LayerOptions — reprojectionErrorThreshold', () => {
   });
 });
 
+describe('JP2LayerOptions — tileSize', () => {
+  it('should accept a numeric tileSize', () => {
+    const opts: JP2LayerOptions = { tileSize: 512 };
+    expect(opts.tileSize).toBe(512);
+  });
+
+  it('should be optional (undefined when not specified)', () => {
+    const opts: JP2LayerOptions = {};
+    expect(opts.tileSize).toBeUndefined();
+  });
+
+  describe('resolveTileSize logic (options?.tileSize ?? 256)', () => {
+    function resolveTileSize(options?: JP2LayerOptions): number {
+      return options?.tileSize ?? 256;
+    }
+
+    it('returns 512 when tileSize is 512', () => {
+      expect(resolveTileSize({ tileSize: 512 })).toBe(512);
+    });
+
+    it('returns 128 when tileSize is 128', () => {
+      expect(resolveTileSize({ tileSize: 128 })).toBe(128);
+    });
+
+    it('returns 256 (default) when tileSize is omitted', () => {
+      expect(resolveTileSize({})).toBe(256);
+    });
+
+    it('returns 256 (default) when options is undefined', () => {
+      expect(resolveTileSize(undefined)).toBe(256);
+    });
+  });
+});
+
 describe('JP2LayerOptions — opaque', () => {
   it('should accept opaque: true', () => {
     const opts: JP2LayerOptions = { opaque: true };

--- a/src/source.ts
+++ b/src/source.ts
@@ -59,7 +59,7 @@ class Semaphore {
   }
 }
 
-const DISPLAY_TILE_SIZE = 256;
+const DEFAULT_DISPLAY_TILE_SIZE = 256;
 
 export interface JP2LayerOptions {
   /** 동시 타일 로드 최대 수 (기본값: 4) */
@@ -160,6 +160,8 @@ export interface JP2LayerOptions {
   reprojectionErrorThreshold?: number;
   /** 타일 소스가 불투명(opaque)함을 렌더러에 알리는 힌트 (기본값: OL 기본값 false). true로 설정하면 하위 레이어 렌더링 생략 최적화 가능 */
   opaque?: boolean;
+  /** 디스플레이 타일 크기 (px, 기본값: 256). 512로 설정하면 네트워크 왕복 감소, 128로 설정하면 HiDPI에서 선명도 향상 */
+  tileSize?: number;
 }
 
 export interface JP2LayerResult {
@@ -207,6 +209,8 @@ export async function createJP2TileLayer(
       : providerOrUrl;
   const info = await provider.init();
   const { width, height, tileWidth, tileHeight, tilesX, tilesY, geoInfo } = info;
+
+  const DISPLAY_TILE_SIZE = options?.tileSize ?? DEFAULT_DISPLAY_TILE_SIZE;
 
   // Compute resolutions in pixel space
   const maxRes = tileWidth / DISPLAY_TILE_SIZE;


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `tileSize?: number` 옵션 추가 (기본값: 256)
- `DISPLAY_TILE_SIZE` 상수를 옵션 값으로 대체하여 TileGrid, 캔버스, subtile 계산에 반영
- 단위 테스트 추가

closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)