### PR TITLE
docs(api): document tileSize, reprojectionErrorThreshold, opaque options (sprint 39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 39
+
+### Added
+- **`JP2LayerOptions.tileSize`**: 디스플레이 타일 크기(px) 옵션 추가 (closes #133, PR #134)
+  - 타입: `number`, 기본값: `256`
+  - `DISPLAY_TILE_SIZE` 상수를 옵션 값으로 대체하여 TileGrid, 캔버스, subtile 계산에 반영
+  - `512`로 설정하면 네트워크 왕복 감소, `128`로 설정하면 HiDPI에서 선명도 향상
+
+---
+
+## [Unreleased] — Sprint 38
+
+### Added
+- **`JP2LayerOptions.reprojectionErrorThreshold`**: 타일 재투영 시 허용 최대 픽셀 오차 임계값 옵션 추가 (closes #129, PR #131)
+  - 타입: `number`, 기본값: OL 기본값 `0.5`
+  - 낮을수록 정확하지만 성능 비용 증가
+  - `TileImage` 소스의 `reprojectionErrorThreshold` 옵션에 전달
+- **`JP2LayerOptions.opaque`**: 타일 소스 불투명 힌트 옵션 추가 (closes #130, PR #131)
+  - 타입: `boolean`, 기본값: OL 기본값 `false`
+  - `true`로 설정하면 렌더러가 하위 레이어 렌더링을 생략하는 최적화 가능
+  - `TileImage` 소스의 `opaque` 옵션에 전달
+
+---
+
 ## [Unreleased] — Sprint 37
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `crossOrigin` | `string \| null` | `undefined` | CORS 크로스오리진 설정. 다른 오리진에서 JP2 파일을 서빙할 때 canvas 픽셀 접근을 위해 필요 (예: `'anonymous'`, `'use-credentials'`) |
 | `extent` | `[number, number, number, number]` | JP2 파일 범위 | 레이어가 렌더링될 지리 범위 `[minX, minY, maxX, maxY]`. 지정 시 해당 범위 내에서만 타일이 렌더링되며, 좌표는 레이어 투영계 단위를 따름 |
 | `tilePixelRatio` | `number` | `1` | HiDPI/Retina 디스플레이용 타일 픽셀 비율. `2`로 설정 시 2배 해상도 타일 요청. `TileImage` 소스의 `tilePixelRatio` 옵션에 전달 |
+| `reprojectionErrorThreshold` | `number` | `0.5` | 타일 재투영(reprojection) 시 허용되는 최대 픽셀 오차 임계값. 낮을수록 정확하지만 성능 비용 증가 |
+| `opaque` | `boolean` | `false` | 타일 소스가 불투명(opaque)함을 렌더러에 알리는 힌트. `true`로 설정하면 하위 레이어 렌더링 생략 최적화 가능 |
+| `tileSize` | `number` | `256` | 디스플레이 타일 크기 (px). `512`로 설정하면 네트워크 왕복 감소, `128`로 설정하면 HiDPI에서 선명도 향상 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- README 옵션 테이블에 `reprojectionErrorThreshold`, `opaque`, `tileSize` 옵션 추가
- CHANGELOG Sprint 38 섹션 추가 (closes #129, closes #130)
- CHANGELOG Sprint 39 섹션 추가 (closes #133)

## Test plan
- [ ] README 옵션 테이블에서 세 항목 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)