### PR TITLE
feat(api): add nodata option to JP2LayerOptions

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -121,5 +121,51 @@ describe('computeMinMax', () => {
     const src = new Uint8Array([100, 200]);
     const result = computeMinMax(src.buffer, 2, 1, 8);
     expect(result).toBeNull();
+  });
+});
+
+describe('applyNodata', () => {
+  it('single nodata value on grayscale: matching pixels become transparent', () => {
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 255,
+      128, 128, 128, 255,
+      0, 0, 0, 255,
+      255, 255, 255, 255,
+    ]);
+    applyNodata(rgba, 2, 2, 1, [0]);
+    expect(rgba[3]).toBe(0);    // pixel 0: nodata
+    expect(rgba[7]).toBe(255);  // pixel 1: kept
+    expect(rgba[11]).toBe(0);   // pixel 2: nodata
+    expect(rgba[15]).toBe(255); // pixel 3: kept
+  });
+
+  it('array of nodata values on grayscale', () => {
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 255,
+      128, 128, 128, 255,
+      255, 255, 255, 255,
+    ]);
+    applyNodata(rgba, 3, 1, 1, [0, 255]);
+    expect(rgba[3]).toBe(0);    // 0 is nodata
+    expect(rgba[7]).toBe(255);  // 128 is not nodata
+    expect(rgba[11]).toBe(0);   // 255 is nodata
+  });
+
+  it('multi-channel: transparent only when all RGB match nodata', () => {
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 255,     // all match → transparent
+      0, 128, 0, 255,   // not all match → opaque
+      10, 10, 10, 255,  // all match → transparent
+    ]);
+    applyNodata(rgba, 3, 1, 3, [0, 10]);
+    expect(rgba[3]).toBe(0);
+    expect(rgba[7]).toBe(255);
+    expect(rgba[11]).toBe(0);
+  });
+
+  it('undefined/empty nodata: no change (caller guards)', () => {
+    const rgba = new Uint8ClampedArray([0, 0, 0, 255]);
+    applyNodata(rgba, 1, 1, 1, []);
+    expect(rgba[3]).toBe(255);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -91,6 +91,35 @@ export function decodedBufferToRGBA(
 }
 
 /**
+ * Applies nodata transparency: sets alpha=0 for pixels matching any nodata value.
+ * For single-channel images, the grayscale value is checked.
+ * For multi-channel images, all RGB channels must match a nodata value.
+ */
+export function applyNodata(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  componentCount: number,
+  nodataValues: number[],
+): void {
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    let isNodata: boolean;
+    if (componentCount === 1) {
+      isNodata = nodataValues.includes(rgba[off]);
+    } else {
+      isNodata = nodataValues.includes(rgba[off])
+        && nodataValues.includes(rgba[off + 1])
+        && nodataValues.includes(rgba[off + 2]);
+    }
+    if (isNodata) {
+      rgba[off + 3] = 0;
+    }
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,6 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
+import { applyNodata } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -162,6 +163,13 @@ export interface JP2LayerOptions {
   opaque?: boolean;
   /** 디스플레이 타일 크기 (px, 기본값: 256). 512로 설정하면 네트워크 왕복 감소, 128로 설정하면 HiDPI에서 선명도 향상 */
   tileSize?: number;
+  /**
+   * 투명으로 처리할 픽셀 값 (no-data value).
+   * 이 값과 정확히 일치하는 픽셀은 alpha=0으로 설정된다.
+   * 다중 채널 이미지: 모든 채널이 nodata 값과 일치할 때만 투명 처리.
+   * 배열로 전달 시 여러 값을 동시에 지정 가능.
+   */
+  nodata?: number | number[];
 }
 
 export interface JP2LayerResult {
@@ -295,6 +303,10 @@ export async function createJP2TileLayer(
   const onTileLoadStart = options?.onTileLoadStart;
   const onProgress = options?.onProgress;
   const colormap = options?.colormap;
+  const nodata = options?.nodata;
+  const nodataValues: number[] | undefined = nodata != null
+    ? (Array.isArray(nodata) ? nodata : [nodata])
+    : undefined;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -406,6 +418,10 @@ export async function createJP2TileLayer(
             emitProgress();
             tile.setState(3);
             return;
+          }
+
+          if (nodataValues && nodataValues.length > 0) {
+            applyNodata(decoded.data, decoded.width, decoded.height, info.componentCount, nodataValues);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `nodata` 옵션 추가 (단일 값 또는 배열)
- 매칭 픽셀의 alpha를 0으로 설정하여 투명 처리
- 단채널: 해당 값 일치 시 투명, 다채널: 모든 RGB 채널이 nodata 값과 일치 시 투명
- colormap 적용 전에 nodata 판별
- `applyNodata` 유틸 함수를 `pixel-conversion.ts`에 추가하여 테스트 용이성 확보

closes #136

## Test plan
- [x] `applyNodata` 단위 테스트 4개 추가 (단일값, 배열, 다채널, 빈 배열)
- [x] `npm test` 전체 통과 (284 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)