### PR TITLE
feat(api): add gamma and nodataTolerance options (#140, #141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `opaque` | `boolean` | `false` | 타일 소스가 불투명함을 렌더러에 알리는 힌트. `true`로 설정하면 하위 레이어 렌더링 생략 최적화 가능. `TileImage` 소스의 `opaque` 옵션에 전달 |
 | `tileSize` | `number` | `256` | 디스플레이 타일 크기 (픽셀). 기본값 256. 고해상도 디스플레이나 성능 튜닝에 활용 |
 | `nodata` | `number` | `undefined` | 투명하게 처리할 픽셀 값. 지정된 값과 일치하는 픽셀의 알파 채널을 0으로 설정하여 투명하게 렌더링 |
+| `nodataTolerance` | `number` | `0` | nodata 값 매칭 허용 오차. `\|pixel - nodata\| <= tolerance` 조건으로 매칭. 16비트→8비트 양자화 오차 보정에 유용 |
+| `gamma` | `number` | `1.0` | 픽셀 감마 보정 값. 1보다 크면 밝아지고, 1보다 작으면 어두워짐. `out = 255 × (in/255)^(1/gamma)` 공식 적용 |
 
 #### 반환값 (`JP2LayerResult`)
 

--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -167,5 +167,62 @@ describe('applyNodata', () => {
     const rgba = new Uint8ClampedArray([0, 0, 0, 255]);
     applyNodata(rgba, 1, 1, 1, []);
     expect(rgba[3]).toBe(255);
+  });
+
+  it('tolerance: pixels within tolerance of nodata become transparent', () => {
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 255,
+      3, 3, 3, 255,
+      5, 5, 5, 255,
+      6, 6, 6, 255,
+    ]);
+    applyNodata(rgba, 2, 2, 1, [0], 5);
+    expect(rgba[3]).toBe(0);    // 0: |0-0|=0 <= 5
+    expect(rgba[7]).toBe(0);    // 3: |3-0|=3 <= 5
+    expect(rgba[11]).toBe(0);   // 5: |5-0|=5 <= 5
+    expect(rgba[15]).toBe(255); // 6: |6-0|=6 > 5
+  });
+
+  it('tolerance=0: behaves like exact match', () => {
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 255,
+      1, 1, 1, 255,
+    ]);
+    applyNodata(rgba, 2, 1, 1, [0], 0);
+    expect(rgba[3]).toBe(0);
+    expect(rgba[7]).toBe(255);
+  });
+});
+
+describe('applyGamma', () => {
+  it('gamma=1.0: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyGamma(rgba, 1, 1, 1.0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('gamma=2.2: pixels become brighter', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 255]);
+    applyGamma(rgba, 1, 1, 2.2);
+    // out = 255 * (100/255)^(1/2.2) ≈ 255 * 0.6467 ≈ 165
+    expect(rgba[0]).toBeGreaterThan(100);
+    expect(rgba[3]).toBe(255); // alpha unchanged
+  });
+
+  it('gamma<1: pixels become darker', () => {
+    const rgba = new Uint8ClampedArray([200, 200, 200, 255]);
+    applyGamma(rgba, 1, 1, 0.5);
+    expect(rgba[0]).toBeLessThan(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('preserves 0 and 255 values', () => {
+    const rgba = new Uint8ClampedArray([0, 255, 128, 255]);
+    applyGamma(rgba, 1, 1, 2.2);
+    expect(rgba[0]).toBe(0);
+    expect(rgba[1]).toBe(255);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -91,6 +91,27 @@ export function decodedBufferToRGBA(
 }
 
 /**
+ * Applies gamma correction to RGB channels: out = 255 * (in/255)^(1/gamma).
+ * Alpha channel is not modified.
+ */
+export function applyGamma(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  gamma: number,
+): void {
+  if (gamma === 1.0) return;
+  const invGamma = 1 / gamma;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = Math.round(255 * Math.pow(rgba[off] / 255, invGamma));
+    rgba[off + 1] = Math.round(255 * Math.pow(rgba[off + 1] / 255, invGamma));
+    rgba[off + 2] = Math.round(255 * Math.pow(rgba[off + 2] / 255, invGamma));
+  }
+}
+
+/**
  * Applies nodata transparency: sets alpha=0 for pixels matching any nodata value.
  * For single-channel images, the grayscale value is checked.
  * For multi-channel images, all RGB channels must match a nodata value.
@@ -101,17 +122,22 @@ export function applyNodata(
   height: number,
   componentCount: number,
   nodataValues: number[],
+  tolerance: number = 0,
 ): void {
   const pixelCount = width * height;
+  const matchesNodata = tolerance > 0
+    ? (v: number) => nodataValues.some(nd => Math.abs(v - nd) <= tolerance)
+    : (v: number) => nodataValues.includes(v);
+
   for (let i = 0; i < pixelCount; i++) {
     const off = i * 4;
     let isNodata: boolean;
     if (componentCount === 1) {
-      isNodata = nodataValues.includes(rgba[off]);
+      isNodata = matchesNodata(rgba[off]);
     } else {
-      isNodata = nodataValues.includes(rgba[off])
-        && nodataValues.includes(rgba[off + 1])
-        && nodataValues.includes(rgba[off + 2]);
+      isNodata = matchesNodata(rgba[off])
+        && matchesNodata(rgba[off + 1])
+        && matchesNodata(rgba[off + 2]);
     }
     if (isNodata) {
       rgba[off + 3] = 0;

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata } from './pixel-conversion';
+import { applyNodata, applyGamma } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -170,6 +170,10 @@ export interface JP2LayerOptions {
    * 배열로 전달 시 여러 값을 동시에 지정 가능.
    */
   nodata?: number | number[];
+  /** nodata 값 매칭 허용 오차 (기본값: 0, 정확히 일치해야 함). 지정 시 |pixel - nodata| <= tolerance 조건으로 매칭 */
+  nodataTolerance?: number;
+  /** 픽셀 감마 보정 값 (기본값: 1.0, 보정 없음). 1보다 크면 밝아지고 1보다 작으면 어두워짐 */
+  gamma?: number;
 }
 
 export interface JP2LayerResult {
@@ -307,6 +311,8 @@ export async function createJP2TileLayer(
   const nodataValues: number[] | undefined = nodata != null
     ? (Array.isArray(nodata) ? nodata : [nodata])
     : undefined;
+  const nodataTolerance = options?.nodataTolerance ?? 0;
+  const gamma = options?.gamma;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -421,7 +427,11 @@ export async function createJP2TileLayer(
           }
 
           if (nodataValues && nodataValues.length > 0) {
-            applyNodata(decoded.data, decoded.width, decoded.height, info.componentCount, nodataValues);
+            applyNodata(decoded.data, decoded.width, decoded.height, info.componentCount, nodataValues, nodataTolerance);
+          }
+
+          if (gamma != null && gamma !== 1.0) {
+            applyGamma(decoded.data, decoded.width, decoded.height, gamma);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- **gamma 옵션** (#140): 픽셀 감마 보정 지원. `out = 255 × (in/255)^(1/gamma)` 공식으로 RGB 채널에 적용. gamma=1.0이면 보정 없음
- **nodataTolerance 옵션** (#141): nodata 값 매칭 시 허용 오차 지원. `|pixel - nodata| <= tolerance` 조건으로 fuzzy 매칭. tolerance=0이면 기존 정확 매칭 유지

### 변경 파일
- `src/pixel-conversion.ts`: `applyGamma` 함수 추가, `applyNodata`에 tolerance 파라미터 추가
- `src/source.ts`: JP2LayerOptions에 gamma/nodataTolerance 필드 추가, 타일 로드 파이프라인에 적용
- `src/pixel-conversion.test.ts`: gamma 및 tolerance 단위 테스트 추가
- `README.md`: 옵션 문서화

closes #140
closes #141

## Test plan
- [x] `npm test` 전체 290개 테스트 통과
- [ ] gamma=2.2로 어두운 JP2 이미지가 밝아지는지 확인
- [ ] nodataTolerance=5로 양자화 오차가 있는 nodata 픽셀이 투명 처리되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)