### PR TITLE
feat(api): add brightness and contrast options to JP2LayerOptions (#143, #144)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -224,5 +224,87 @@ describe('applyGamma', () => {
     applyGamma(rgba, 1, 1, 2.2);
     expect(rgba[0]).toBe(0);
     expect(rgba[1]).toBe(255);
+  });
+});
+
+describe('applyBrightness', () => {
+  it('brightness=0: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyBrightness(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('brightness=1: all pixels become 255', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyBrightness(rgba, 1, 1, 1);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(255);
+    expect(rgba[2]).toBe(255);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('brightness=-1: all pixels become 0', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyBrightness(rgba, 1, 1, -1);
+    expect(rgba[0]).toBe(0);
+    expect(rgba[1]).toBe(0);
+    expect(rgba[2]).toBe(0);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('positive brightness increases pixel values', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 255]);
+    applyBrightness(rgba, 1, 1, 0.5);
+    // 100 + 128 = 228
+    expect(rgba[0]).toBe(228);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('clamps to 0-255 range', () => {
+    const rgba = new Uint8ClampedArray([200, 50, 100, 255]);
+    applyBrightness(rgba, 1, 1, 0.5);
+    expect(rgba[0]).toBe(255); // 200+128 clamped
+    expect(rgba[1]).toBe(178); // 50+128
+  });
+});
+
+describe('applyContrast', () => {
+  it('contrast=1.0: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyContrast(rgba, 1, 1, 1.0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('contrast=0: all pixels become 128 (mid-gray)', () => {
+    const rgba = new Uint8ClampedArray([0, 100, 255, 255]);
+    applyContrast(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(128);
+    expect(rgba[1]).toBe(128);
+    expect(rgba[2]).toBe(128);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('contrast=2: doubles contrast', () => {
+    const rgba = new Uint8ClampedArray([192, 64, 128, 255]);
+    applyContrast(rgba, 1, 1, 2);
+    // (192-128)*2+128 = 256 → clamped to 255
+    expect(rgba[0]).toBe(255);
+    // (64-128)*2+128 = 0
+    expect(rgba[1]).toBe(0);
+    // (128-128)*2+128 = 128
+    expect(rgba[2]).toBe(128);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 200]);
+    applyContrast(rgba, 1, 1, 2);
+    expect(rgba[3]).toBe(200);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -146,6 +146,47 @@ export function applyNodata(
 }
 
 /**
+ * Applies brightness adjustment to RGB channels: out = in + brightness * 255.
+ * Alpha channel is not modified.
+ */
+export function applyBrightness(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  brightness: number,
+): void {
+  if (brightness === 0) return;
+  const offset = Math.round(brightness * 255);
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = rgba[off] + offset;
+    rgba[off + 1] = rgba[off + 1] + offset;
+    rgba[off + 2] = rgba[off + 2] + offset;
+  }
+}
+
+/**
+ * Applies contrast adjustment to RGB channels: out = (in - 128) * contrast + 128.
+ * Alpha channel is not modified.
+ */
+export function applyContrast(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  contrast: number,
+): void {
+  if (contrast === 1.0) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = (rgba[off] - 128) * contrast + 128;
+    rgba[off + 1] = (rgba[off + 1] - 128) * contrast + 128;
+    rgba[off + 2] = (rgba[off + 2] - 128) * contrast + 128;
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -174,6 +174,10 @@ export interface JP2LayerOptions {
   nodataTolerance?: number;
   /** 픽셀 감마 보정 값 (기본값: 1.0, 보정 없음). 1보다 크면 밝아지고 1보다 작으면 어두워짐 */
   gamma?: number;
+  /** 픽셀 밝기 조정 값 (기본값: 0, 조정 없음). -1 ~ 1 범위. 양수면 밝아지고 음수면 어두워짐 */
+  brightness?: number;
+  /** 픽셀 대비 조정 값 (기본값: 1.0, 조정 없음). 1보다 크면 대비 증가, 0~1이면 대비 감소, 0이면 회색 */
+  contrast?: number;
 }
 
 export interface JP2LayerResult {
@@ -313,6 +317,8 @@ export async function createJP2TileLayer(
     : undefined;
   const nodataTolerance = options?.nodataTolerance ?? 0;
   const gamma = options?.gamma;
+  const brightness = options?.brightness;
+  const contrast = options?.contrast;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -432,6 +438,14 @@ export async function createJP2TileLayer(
 
           if (gamma != null && gamma !== 1.0) {
             applyGamma(decoded.data, decoded.width, decoded.height, gamma);
+          }
+
+          if (brightness != null && brightness !== 0) {
+            applyBrightness(decoded.data, decoded.width, decoded.height, brightness);
+          }
+
+          if (contrast != null && contrast !== 1.0) {
+            applyContrast(decoded.data, decoded.width, decoded.height, contrast);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `brightness` 옵션 추가: -1~1 범위로 픽셀 밝기 조정 (`applyBrightness()`)
- `contrast` 옵션 추가: 0 이상 값으로 픽셀 대비 조정 (`applyContrast()`)
- 적용 순서: nodata → gamma → brightness → contrast → colormap/bands

closes #143, closes #144

## Test plan
- [x] `npm test` 전체 299개 통과
- [ ] brightness=0, contrast=1.0 시 픽셀 변화 없음 확인
- [ ] brightness=1/-1 극값, contrast=0/2 극값 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)