### PR TITLE
feat(api): add saturation and hue options to JP2LayerOptions (#147, #148)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -306,5 +306,81 @@ describe('applyContrast', () => {
     const rgba = new Uint8ClampedArray([100, 100, 100, 200]);
     applyContrast(rgba, 1, 1, 2);
     expect(rgba[3]).toBe(200);
+  });
+});
+
+describe('applySaturation', () => {
+  it('saturation=1.0: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applySaturation(rgba, 1, 1, 1.0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('saturation=0: grayscale', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255]);
+    applySaturation(rgba, 1, 1, 0);
+    // gray = 0.2126*255 + 0.7152*0 + 0.0722*0 ≈ 54
+    const gray = Math.round(0.2126 * 255);
+    expect(rgba[0]).toBe(gray);
+    expect(rgba[1]).toBe(gray);
+    expect(rgba[2]).toBe(gray);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('saturation=2: oversaturated', () => {
+    const rgba = new Uint8ClampedArray([200, 100, 100, 255]);
+    applySaturation(rgba, 1, 1, 2);
+    expect(rgba[0]).toBeGreaterThan(200);
+    expect(rgba[1]).toBeLessThan(100);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 128]);
+    applySaturation(rgba, 1, 1, 0);
+    expect(rgba[3]).toBe(128);
+  });
+});
+
+describe('applyHue', () => {
+  it('hue=0: no change', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255]);
+    applyHue(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(0);
+    expect(rgba[2]).toBe(0);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('hue=360: full rotation returns to original', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255]);
+    applyHue(rgba, 1, 1, 360);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(0);
+    expect(rgba[2]).toBe(0);
+  });
+
+  it('hue=120: red shifts toward green', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255]);
+    applyHue(rgba, 1, 1, 120);
+    // Red (H=0) + 120° → H=120° → green
+    expect(rgba[0]).toBeLessThan(255);
+    expect(rgba[1]).toBeGreaterThan(0);
+  });
+
+  it('achromatic pixels unchanged', () => {
+    const rgba = new Uint8ClampedArray([128, 128, 128, 255]);
+    applyHue(rgba, 1, 1, 90);
+    expect(rgba[0]).toBe(128);
+    expect(rgba[1]).toBe(128);
+    expect(rgba[2]).toBe(128);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 100]);
+    applyHue(rgba, 1, 1, 180);
+    expect(rgba[3]).toBe(100);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -187,6 +187,72 @@ export function applyContrast(
 }
 
 /**
+ * Applies saturation adjustment to RGB channels.
+ * saturation=0: grayscale, saturation=1: original, saturation>1: oversaturated.
+ * Alpha channel is not modified.
+ */
+export function applySaturation(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  saturation: number,
+): void {
+  if (saturation === 1.0) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const r = rgba[off], g = rgba[off + 1], b = rgba[off + 2];
+    const gray = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    rgba[off]     = Math.round(gray + saturation * (r - gray));
+    rgba[off + 1] = Math.round(gray + saturation * (g - gray));
+    rgba[off + 2] = Math.round(gray + saturation * (b - gray));
+  }
+}
+
+/**
+ * Applies hue rotation to RGB channels.
+ * hueDegrees=0: no change, 180: complementary colors.
+ * Uses RGB→HSL→RGB conversion. Alpha channel is not modified.
+ */
+export function applyHue(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  hueDegrees: number,
+): void {
+  if (hueDegrees === 0) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const r = rgba[off] / 255, g = rgba[off + 1] / 255, b = rgba[off + 2] / 255;
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    if (max === min) continue; // achromatic, no hue to rotate
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h: number;
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (max === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+    h = ((h + hueDegrees / 360) % 1 + 1) % 1;
+    // HSL to RGB
+    const hue2rgb = (p: number, q: number, t: number) => {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1/6) return p + (q - p) * 6 * t;
+      if (t < 1/2) return q;
+      if (t < 2/3) return p + (q - p) * (2/3 - t) * 6;
+      return p;
+    };
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    rgba[off]     = Math.round(hue2rgb(p, q, h + 1/3) * 255);
+    rgba[off + 1] = Math.round(hue2rgb(p, q, h) * 255);
+    rgba[off + 2] = Math.round(hue2rgb(p, q, h - 1/3) * 255);
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -178,6 +178,10 @@ export interface JP2LayerOptions {
   brightness?: number;
   /** 픽셀 대비 조정 값 (기본값: 1.0, 조정 없음). 1보다 크면 대비 증가, 0~1이면 대비 감소, 0이면 회색 */
   contrast?: number;
+  /** 픽셀 채도 조정 값 (기본값: 1.0, 조정 없음). 0이면 흑백, 1보다 크면 채도 증가 */
+  saturation?: number;
+  /** 픽셀 색조 회전 각도 (기본값: 0, 단위: 도). 180이면 보색, ±360은 한 바퀴 회전 */
+  hue?: number;
 }
 
 export interface JP2LayerResult {
@@ -319,6 +323,8 @@ export async function createJP2TileLayer(
   const gamma = options?.gamma;
   const brightness = options?.brightness;
   const contrast = options?.contrast;
+  const saturation = options?.saturation;
+  const hue = options?.hue;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -446,6 +452,14 @@ export async function createJP2TileLayer(
 
           if (contrast != null && contrast !== 1.0) {
             applyContrast(decoded.data, decoded.width, decoded.height, contrast);
+          }
+
+          if (saturation != null && saturation !== 1.0) {
+            applySaturation(decoded.data, decoded.width, decoded.height, saturation);
+          }
+
+          if (hue != null && hue !== 0) {
+            applyHue(decoded.data, decoded.width, decoded.height, hue);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `applySaturation()`: 픽셀 채도 조정 (0=흑백, 1=원본, >1=과채도)
- `applyHue()`: RGB↔HSL 변환을 통한 색조 회전 (단위: 도)
- `JP2LayerOptions`에 `saturation`, `hue` 옵션 추가
- brightness/contrast 이후에 순차 적용

closes #147
closes #148

## Test plan
- [x] `applySaturation` 단위 테스트 4개 통과
- [x] `applyHue` 단위 테스트 5개 통과
- [x] `npm test` 전체 308개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)