### PR TITLE
feat(api): add blur and sepia options (#159, #160)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -526,5 +526,113 @@ describe('applySharpen', () => {
     for (let i = 0; i < 9; i++) {
       expect(rgba[i * 4 + 3]).toBe(50);
     }
+  });
+});
+
+describe('applyBlur', () => {
+  it('passes=0: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyBlur(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('blurs a 3x3 image with bright center', () => {
+    const rgba = new Uint8ClampedArray([
+      0,0,0,255,   0,0,0,255,   0,0,0,255,
+      0,0,0,255,   255,255,255,255, 0,0,0,255,
+      0,0,0,255,   0,0,0,255,   0,0,0,255,
+    ]);
+    applyBlur(rgba, 3, 3, 1);
+    // Center pixel should be reduced (blurred)
+    const centerOff = 4 * 4;
+    expect(rgba[centerOff]).toBeLessThan(255);
+    expect(rgba[centerOff]).toBeGreaterThan(0);
+    // Corner pixels should gain some brightness
+    expect(rgba[0]).toBeGreaterThan(0);
+  });
+
+  it('multiple passes increase blur effect', () => {
+    const make = () => new Uint8ClampedArray([
+      0,0,0,255,   0,0,0,255,   0,0,0,255,
+      0,0,0,255,   255,255,255,255, 0,0,0,255,
+      0,0,0,255,   0,0,0,255,   0,0,0,255,
+    ]);
+    const rgba1 = make();
+    applyBlur(rgba1, 3, 3, 1);
+    const rgba2 = make();
+    applyBlur(rgba2, 3, 3, 2);
+    // Center should be more reduced with 2 passes
+    const centerOff = 4 * 4;
+    expect(rgba2[centerOff]).toBeLessThan(rgba1[centerOff]);
+  });
+
+  it('uniform image unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      100,100,100,255, 100,100,100,255,
+      100,100,100,255, 100,100,100,255,
+    ]);
+    applyBlur(rgba, 2, 2, 1);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[4]).toBe(100);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      100,100,100,50,  100,100,100,50,  100,100,100,50,
+      100,100,100,50,  200,200,200,50,  100,100,100,50,
+      100,100,100,50,  100,100,100,50,  100,100,100,50,
+    ]);
+    applyBlur(rgba, 3, 3, 1);
+    for (let i = 0; i < 9; i++) {
+      expect(rgba[i * 4 + 3]).toBe(50);
+    }
+  });
+});
+
+describe('applySepia', () => {
+  it('intensity=0: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applySepia(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('intensity=1: full sepia tone', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    const r = 100, g = 150, b = 200;
+    const sr = Math.min(255, Math.round(r * 0.393 + g * 0.769 + b * 0.189));
+    const sg = Math.min(255, Math.round(r * 0.349 + g * 0.686 + b * 0.168));
+    const sb = Math.min(255, Math.round(r * 0.272 + g * 0.534 + b * 0.131));
+    applySepia(rgba, 1, 1, 1);
+    expect(rgba[0]).toBe(sr);
+    expect(rgba[1]).toBe(sg);
+    expect(rgba[2]).toBe(sb);
+  });
+
+  it('intensity=0.5: 50% blend', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    const r = 100, g = 150, b = 200;
+    const sr = Math.min(255, r * 0.393 + g * 0.769 + b * 0.189);
+    const expected = Math.round(r + 0.5 * (sr - r));
+    applySepia(rgba, 1, 1, 0.5);
+    expect(rgba[0]).toBe(expected);
+  });
+
+  it('sepia R >= G >= B (warm tone)', () => {
+    const rgba = new Uint8ClampedArray([128, 128, 128, 255]);
+    applySepia(rgba, 1, 1, 1);
+    expect(rgba[0]).toBeGreaterThanOrEqual(rgba[1]);
+    expect(rgba[1]).toBeGreaterThanOrEqual(rgba[2]);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 100]);
+    applySepia(rgba, 1, 1, 1);
+    expect(rgba[3]).toBe(100);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -362,6 +362,75 @@ export function applySharpen(
 }
 
 /**
+ * Applies Gaussian blur smoothing to RGBA data.
+ * Uses a 3×3 Gaussian kernel [1,2,1; 2,4,2; 1,2,1]/16.
+ * The blur parameter controls number of passes (iterations).
+ * Alpha channel is not modified.
+ */
+export function applyBlur(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  passes: number,
+): void {
+  if (passes <= 0) return;
+  const pixelCount = width * height;
+  for (let p = 0; p < passes; p++) {
+    const tmp = new Uint8ClampedArray(pixelCount * 4);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        let sumR = 0, sumG = 0, sumB = 0;
+        let wSum = 0;
+        for (let ky = -1; ky <= 1; ky++) {
+          for (let kx = -1; kx <= 1; kx++) {
+            const ny = y + ky, nx = x + kx;
+            if (ny < 0 || ny >= height || nx < 0 || nx >= width) continue;
+            const w = (kx === 0 && ky === 0) ? 4 : (kx === 0 || ky === 0) ? 2 : 1;
+            const off = (ny * width + nx) * 4;
+            sumR += rgba[off] * w;
+            sumG += rgba[off + 1] * w;
+            sumB += rgba[off + 2] * w;
+            wSum += w;
+          }
+        }
+        const dstOff = (y * width + x) * 4;
+        tmp[dstOff]     = Math.round(sumR / wSum);
+        tmp[dstOff + 1] = Math.round(sumG / wSum);
+        tmp[dstOff + 2] = Math.round(sumB / wSum);
+        tmp[dstOff + 3] = rgba[dstOff + 3];
+      }
+    }
+    rgba.set(tmp);
+  }
+}
+
+/**
+ * Applies sepia tone effect to RGBA data.
+ * Uses ITU-R sepia transform matrix with intensity-based linear interpolation.
+ * intensity=0: no change, intensity=1: full sepia.
+ * Alpha channel is not modified.
+ */
+export function applySepia(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  intensity: number,
+): void {
+  if (intensity === 0) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const r = rgba[off], g = rgba[off + 1], b = rgba[off + 2];
+    const sr = Math.min(255, r * 0.393 + g * 0.769 + b * 0.189);
+    const sg = Math.min(255, r * 0.349 + g * 0.686 + b * 0.168);
+    const sb = Math.min(255, r * 0.272 + g * 0.534 + b * 0.131);
+    rgba[off]     = Math.round(r + intensity * (sr - r));
+    rgba[off + 1] = Math.round(g + intensity * (sg - g));
+    rgba[off + 2] = Math.round(b + intensity * (sb - b));
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -190,6 +190,10 @@ export interface JP2LayerOptions {
   colorize?: [number, number, number];
   /** 언샤프 마스킹 선명화 강도 (0.0~1.0, 기본값: 0). 3x3 가우시안 블러 기반 선명화 */
   sharpen?: number;
+  /** 가우시안 블러 스무딩 적용 횟수 (기본값: 0, 비활성화). 3×3 커널 반복 적용 */
+  blur?: number;
+  /** 세피아 톤 효과 강도 (0~1, 기본값: 0). 0=원본, 1=완전 세피아 */
+  sepia?: number;
 }
 
 export interface JP2LayerResult {
@@ -337,6 +341,8 @@ export async function createJP2TileLayer(
   const threshold = options?.threshold;
   const colorize = options?.colorize;
   const sharpen = options?.sharpen;
+  const blur = options?.blur;
+  const sepia = options?.sepia;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -488,6 +494,14 @@ export async function createJP2TileLayer(
 
           if (sharpen != null && sharpen !== 0) {
             applySharpen(decoded.data, decoded.width, decoded.height, sharpen);
+          }
+
+          if (blur != null && blur > 0) {
+            applyBlur(decoded.data, decoded.width, decoded.height, blur);
+          }
+
+          if (sepia != null && sepia !== 0) {
+            applySepia(decoded.data, decoded.width, decoded.height, sepia);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- **blur** 옵션 추가: 3×3 가우시안 커널을 반복 적용하여 노이즈 감소/스무딩 효과 (`applyBlur`)
- **sepia** 옵션 추가: ITU-R 세피아 변환 행렬 + intensity 기반 선형 보간 (`applySepia`)
- 단위 테스트 10개 추가 (blur 5개, sepia 5개), 전체 333개 테스트 통과

closes #159, closes #160

## Test plan
- [x] `npm test` 전체 통과 (333 tests)
- [ ] blur=0, blur=1, blur=2 적용 시 시각적 확인
- [ ] sepia=0, sepia=0.5, sepia=1 적용 시 시각적 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)