### PR TITLE
feat(api): add grayscale and colorMap options (#163, #164)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -709,5 +709,50 @@ describe('applyColorMap', () => {
     const rgba = new Uint8ClampedArray([100, 100, 100, 50]);
     applyColorMap(rgba, 1, 1, colorMap);
     expect(rgba[3]).toBe(50);
+  });
+});
+
+describe('validateColorMap', () => {
+  const makeValidMap = (): Array<[number, number, number]> =>
+    Array.from({ length: 256 }, (_, i) => [i, i, i] as [number, number, number]);
+
+  it('should accept a valid 256-entry colorMap', () => {
+    expect(validateColorMap(makeValidMap())).toBe(true);
+  });
+
+  it('should reject non-array input', () => {
+    expect(validateColorMap(null)).toBe(false);
+    expect(validateColorMap('string')).toBe(false);
+    expect(validateColorMap(42)).toBe(false);
+  });
+
+  it('should reject array with wrong length', () => {
+    expect(validateColorMap([[0, 0, 0]])).toBe(false);
+    const tooMany = Array.from({ length: 257 }, () => [0, 0, 0]);
+    expect(validateColorMap(tooMany)).toBe(false);
+  });
+
+  it('should reject entries with wrong tuple length', () => {
+    const map = makeValidMap();
+    (map[0] as unknown as number[]) = [0, 0];
+    expect(validateColorMap(map)).toBe(false);
+  });
+
+  it('should reject entries with out-of-range values', () => {
+    const map = makeValidMap();
+    map[100] = [256, 0, 0];
+    expect(validateColorMap(map)).toBe(false);
+  });
+
+  it('should reject entries with negative values', () => {
+    const map = makeValidMap();
+    map[50] = [-1, 0, 0];
+    expect(validateColorMap(map)).toBe(false);
+  });
+
+  it('should reject entries with non-number values', () => {
+    const map = makeValidMap();
+    (map[0] as unknown) = ['a', 0, 0];
+    expect(validateColorMap(map)).toBe(false);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -454,6 +454,33 @@ export function applyGrayscale(
  * Each entry is an [R, G, B] tuple. Alpha channel is not modified.
  * Only applies when componentCount === 1; multi-channel images are ignored.
  */
+/**
+ * Validates the colorMap option.
+ * Must be an array of exactly 256 entries, each an [R, G, B] tuple with values 0~255.
+ * Returns true if valid, false otherwise.
+ */
+export function validateColorMap(
+  colorMap: unknown,
+): colorMap is Array<[number, number, number]> {
+  if (!Array.isArray(colorMap) || colorMap.length !== 256) return false;
+  for (let i = 0; i < 256; i++) {
+    const entry = colorMap[i];
+    if (
+      !Array.isArray(entry) ||
+      entry.length !== 3 ||
+      typeof entry[0] !== 'number' ||
+      typeof entry[1] !== 'number' ||
+      typeof entry[2] !== 'number' ||
+      entry[0] < 0 || entry[0] > 255 ||
+      entry[1] < 0 || entry[1] > 255 ||
+      entry[2] < 0 || entry[2] > 255
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function applyColorMap(
   rgba: Uint8ClampedArray,
   width: number,

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -347,8 +347,11 @@ export async function createJP2TileLayer(
   const sharpen = options?.sharpen;
   const blur = options?.blur;
   const sepia = options?.sepia;
+  const colorMapLUT = options?.colorMap != null && validateColorMap(options.colorMap)
+    ? options.colorMap
+    : undefined;
+  // colorMap takes priority over grayscale for single-band images
   const grayscale = options?.grayscale;
-  const colorMapLUT = options?.colorMap;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -510,12 +513,11 @@ export async function createJP2TileLayer(
             applySepia(decoded.data, decoded.width, decoded.height, sepia);
           }
 
-          if (grayscale) {
-            applyGrayscale(decoded.data, decoded.width, decoded.height);
-          }
-
           if (colorMapLUT && info.componentCount === 1) {
+            // colorMap takes priority: skip grayscale for single-band images
             applyColorMap(decoded.data, decoded.width, decoded.height, colorMapLUT);
+          } else if (grayscale) {
+            applyGrayscale(decoded.data, decoded.width, decoded.height);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `JP2LayerOptions.grayscale`: boolean 옵션 추가 — ITU-R BT.709 가중치로 컬러 이미지를 그레이스케일 변환 (closes #163)
- `JP2LayerOptions.colorMap`: `Array<[number, number, number]>` (길이 256) 옵션 추가 — 단일 밴드 데이터에 색상 룩업 테이블 적용, 멀티 채널 이미지에서는 무시 (closes #164)
- colorMap과 grayscale 동시 사용 시 단일 밴드에서는 colorMap 우선 적용 (closes #166)
- `validateColorMap()` 유효성 검사 함수 추가 — 비유효 입력은 무시 처리 (closes #167)
- `applyGrayscale()`, `applyColorMap()`, `validateColorMap()` 함수를 `pixel-conversion.ts`에 추가
- 단위 테스트 14개 추가 (총 347개 통과)

## Test plan
- [x] `npm test` — 347개 테스트 모두 통과
- [ ] Reviewer: grayscale/colorMap 우선순위 및 유효성 검사 로직 확인
- [ ] Tester: E2E 테스트에서 새 옵션 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)