### PR TITLE
docs(changelog): add Sprint 48 entries for grayscale/colorMap priority and validateColorMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 48
+
+### Fixed
+- **grayscale/colorMap 우선순위 명확화** (closes #166, PR #165): 단일 밴드 이미지에서 `colorMap`과 `grayscale`을 동시 사용 시 `colorMap`이 우선 적용되도록 동작 명확화 및 문서화
+
+### Added
+- **`validateColorMap()` 유효성 검사** (closes #167, PR #165): `colorMap` 옵션 입력값 유효성 검사 함수 추가
+  - 길이가 256이 아니거나 각 항목이 `[r, g, b]` 3원소 배열이 아닌 경우 무시(fallback) 처리
+  - `pixel-conversion.ts`의 `validateColorMap()` 함수로 처리
+
+---
+
 ## [Unreleased] — Sprint 45
 
 ### Added

--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -634,5 +634,80 @@ describe('applySepia', () => {
     const rgba = new Uint8ClampedArray([100, 150, 200, 100]);
     applySepia(rgba, 1, 1, 1);
     expect(rgba[3]).toBe(100);
+  });
+});
+
+describe('applyGrayscale', () => {
+  it('converts RGB to grayscale using BT.709 weights', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255]);
+    applyGrayscale(rgba, 1, 1);
+    const expected = Math.round(0.2126 * 255);
+    expect(rgba[0]).toBe(expected);
+    expect(rgba[1]).toBe(expected);
+    expect(rgba[2]).toBe(expected);
+  });
+
+  it('pure white stays white', () => {
+    const rgba = new Uint8ClampedArray([255, 255, 255, 255]);
+    applyGrayscale(rgba, 1, 1);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(255);
+    expect(rgba[2]).toBe(255);
+  });
+
+  it('pure black stays black', () => {
+    const rgba = new Uint8ClampedArray([0, 0, 0, 255]);
+    applyGrayscale(rgba, 1, 1);
+    expect(rgba[0]).toBe(0);
+  });
+
+  it('already gray pixel unchanged', () => {
+    const rgba = new Uint8ClampedArray([128, 128, 128, 255]);
+    applyGrayscale(rgba, 1, 1);
+    expect(rgba[0]).toBe(128);
+    expect(rgba[1]).toBe(128);
+    expect(rgba[2]).toBe(128);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 100]);
+    applyGrayscale(rgba, 1, 1);
+    expect(rgba[3]).toBe(100);
+  });
+});
+
+describe('applyColorMap', () => {
+  it('maps grayscale values to colors via LUT', () => {
+    // Create a simple colorMap: index 0 → blue, index 128 → green, index 255 → red
+    const colorMap: Array<[number, number, number]> = Array.from({ length: 256 }, () => [0, 0, 0] as [number, number, number]);
+    colorMap[0] = [0, 0, 255];
+    colorMap[128] = [0, 255, 0];
+    colorMap[255] = [255, 0, 0];
+
+    const rgba = new Uint8ClampedArray([
+      0, 0, 0, 255,
+      128, 128, 128, 255,
+      255, 255, 255, 255,
+    ]);
+    applyColorMap(rgba, 3, 1, colorMap);
+    // pixel 0: index 0 → blue
+    expect(rgba[0]).toBe(0);
+    expect(rgba[1]).toBe(0);
+    expect(rgba[2]).toBe(255);
+    // pixel 1: index 128 → green
+    expect(rgba[4]).toBe(0);
+    expect(rgba[5]).toBe(255);
+    expect(rgba[6]).toBe(0);
+    // pixel 2: index 255 → red
+    expect(rgba[8]).toBe(255);
+    expect(rgba[9]).toBe(0);
+    expect(rgba[10]).toBe(0);
+  });
+
+  it('alpha channel unchanged', () => {
+    const colorMap: Array<[number, number, number]> = Array.from({ length: 256 }, () => [255, 0, 0] as [number, number, number]);
+    const rgba = new Uint8ClampedArray([100, 100, 100, 50]);
+    applyColorMap(rgba, 1, 1, colorMap);
+    expect(rgba[3]).toBe(50);
   });
 });

--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -709,5 +709,50 @@ describe('applyColorMap', () => {
     const rgba = new Uint8ClampedArray([100, 100, 100, 50]);
     applyColorMap(rgba, 1, 1, colorMap);
     expect(rgba[3]).toBe(50);
+  });
+});
+
+describe('validateColorMap', () => {
+  const makeValidMap = (): Array<[number, number, number]> =>
+    Array.from({ length: 256 }, (_, i) => [i, i, i] as [number, number, number]);
+
+  it('should accept a valid 256-entry colorMap', () => {
+    expect(validateColorMap(makeValidMap())).toBe(true);
+  });
+
+  it('should reject non-array input', () => {
+    expect(validateColorMap(null)).toBe(false);
+    expect(validateColorMap('string')).toBe(false);
+    expect(validateColorMap(42)).toBe(false);
+  });
+
+  it('should reject array with wrong length', () => {
+    expect(validateColorMap([[0, 0, 0]])).toBe(false);
+    const tooMany = Array.from({ length: 257 }, () => [0, 0, 0]);
+    expect(validateColorMap(tooMany)).toBe(false);
+  });
+
+  it('should reject entries with wrong tuple length', () => {
+    const map = makeValidMap();
+    (map[0] as unknown as number[]) = [0, 0];
+    expect(validateColorMap(map)).toBe(false);
+  });
+
+  it('should reject entries with out-of-range values', () => {
+    const map = makeValidMap();
+    map[100] = [256, 0, 0];
+    expect(validateColorMap(map)).toBe(false);
+  });
+
+  it('should reject entries with negative values', () => {
+    const map = makeValidMap();
+    map[50] = [-1, 0, 0];
+    expect(validateColorMap(map)).toBe(false);
+  });
+
+  it('should reject entries with non-number values', () => {
+    const map = makeValidMap();
+    (map[0] as unknown) = ['a', 0, 0];
+    expect(validateColorMap(map)).toBe(false);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -431,6 +431,47 @@ export function applySepia(
 }
 
 /**
+ * Converts RGB pixels to grayscale using ITU-R BT.709 weights.
+ * Each pixel: gray = 0.2126*R + 0.7152*G + 0.0722*B.
+ * Alpha channel is not modified.
+ */
+export function applyGrayscale(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+): void {
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const gray = Math.round(0.2126 * rgba[off] + 0.7152 * rgba[off + 1] + 0.0722 * rgba[off + 2]);
+    rgba[off] = rgba[off + 1] = rgba[off + 2] = gray;
+  }
+}
+
+/**
+ * Applies a color lookup table to single-band (grayscale) RGBA data.
+ * The grayscale value (0~255) is used as an index into the 256-entry colorMap.
+ * Each entry is an [R, G, B] tuple. Alpha channel is not modified.
+ * Only applies when componentCount === 1; multi-channel images are ignored.
+ */
+export function applyColorMap(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  colorMap: Array<[number, number, number]>,
+): void {
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const idx = rgba[off];
+    const entry = colorMap[idx];
+    rgba[off] = entry[0];
+    rgba[off + 1] = entry[1];
+    rgba[off + 2] = entry[2];
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -454,6 +454,33 @@ export function applyGrayscale(
  * Each entry is an [R, G, B] tuple. Alpha channel is not modified.
  * Only applies when componentCount === 1; multi-channel images are ignored.
  */
+/**
+ * Validates the colorMap option.
+ * Must be an array of exactly 256 entries, each an [R, G, B] tuple with values 0~255.
+ * Returns true if valid, false otherwise.
+ */
+export function validateColorMap(
+  colorMap: unknown,
+): colorMap is Array<[number, number, number]> {
+  if (!Array.isArray(colorMap) || colorMap.length !== 256) return false;
+  for (let i = 0; i < 256; i++) {
+    const entry = colorMap[i];
+    if (
+      !Array.isArray(entry) ||
+      entry.length !== 3 ||
+      typeof entry[0] !== 'number' ||
+      typeof entry[1] !== 'number' ||
+      typeof entry[2] !== 'number' ||
+      entry[0] < 0 || entry[0] > 255 ||
+      entry[1] < 0 || entry[1] > 255 ||
+      entry[2] < 0 || entry[2] > 255
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 export function applyColorMap(
   rgba: Uint8ClampedArray,
   width: number,

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -194,6 +194,10 @@ export interface JP2LayerOptions {
   blur?: number;
   /** 세피아 톤 효과 강도 (0~1, 기본값: 0). 0=원본, 1=완전 세피아 */
   sepia?: number;
+  /** 이미지를 그레이스케일로 변환 (기본값: false). ITU-R BT.709 가중치 사용 */
+  grayscale?: boolean;
+  /** 단일 밴드 데이터에 적용할 색상 룩업 테이블 (길이 256 배열, 각 요소 [R, G, B]). 밴드 수 > 1이면 무시 */
+  colorMap?: Array<[number, number, number]>;
 }
 
 export interface JP2LayerResult {
@@ -343,6 +347,8 @@ export async function createJP2TileLayer(
   const sharpen = options?.sharpen;
   const blur = options?.blur;
   const sepia = options?.sepia;
+  const grayscale = options?.grayscale;
+  const colorMapLUT = options?.colorMap;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -502,6 +508,14 @@ export async function createJP2TileLayer(
 
           if (sepia != null && sepia !== 0) {
             applySepia(decoded.data, decoded.width, decoded.height, sepia);
+          }
+
+          if (grayscale) {
+            applyGrayscale(decoded.data, decoded.width, decoded.height);
+          }
+
+          if (colorMapLUT && info.componentCount === 1) {
+            applyColorMap(decoded.data, decoded.width, decoded.height, colorMapLUT);
           }
 
           if (colormap && info.componentCount === 1) {

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -347,8 +347,11 @@ export async function createJP2TileLayer(
   const sharpen = options?.sharpen;
   const blur = options?.blur;
   const sepia = options?.sepia;
+  const colorMapLUT = options?.colorMap != null && validateColorMap(options.colorMap)
+    ? options.colorMap
+    : undefined;
+  // colorMap takes priority over grayscale for single-band images
   const grayscale = options?.grayscale;
-  const colorMapLUT = options?.colorMap;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -510,12 +513,11 @@ export async function createJP2TileLayer(
             applySepia(decoded.data, decoded.width, decoded.height, sepia);
           }
 
-          if (grayscale) {
-            applyGrayscale(decoded.data, decoded.width, decoded.height);
-          }
-
           if (colorMapLUT && info.componentCount === 1) {
+            // colorMap takes priority: skip grayscale for single-band images
             applyColorMap(decoded.data, decoded.width, decoded.height, colorMapLUT);
+          } else if (grayscale) {
+            applyGrayscale(decoded.data, decoded.width, decoded.height);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 48 항목 추가
- `grayscale`/`colorMap` 우선순위 명확화 문서화 (closes #166)
- `validateColorMap()` 유효성 검사 함수 문서화 (closes #167)

## Test plan
- [ ] CHANGELOG 내용 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)