### PR TITLE
feat(api): add posterize and vignette options (#170, #171)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -754,5 +754,92 @@ describe('validateColorMap', () => {
     const map = makeValidMap();
     (map[0] as unknown) = ['a', 0, 0];
     expect(validateColorMap(map)).toBe(false);
+  });
+});
+
+describe('applyPosterize', () => {
+  it('levels < 2: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyPosterize(rgba, 1, 1, 1);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('levels >= 256: no change', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyPosterize(rgba, 1, 1, 256);
+    expect(rgba[0]).toBe(100);
+  });
+
+  it('levels=2: binary posterization', () => {
+    const rgba = new Uint8ClampedArray([
+      64, 64, 64, 255,
+      192, 192, 192, 255,
+    ]);
+    applyPosterize(rgba, 2, 1, 2);
+    // step = 255, round(64/255)*255 = 0, round(192/255)*255 = 255
+    expect(rgba[0]).toBe(0);
+    expect(rgba[4]).toBe(255);
+  });
+
+  it('levels=4: quantizes to 4 levels (0, 85, 170, 255)', () => {
+    const rgba = new Uint8ClampedArray([40, 100, 180, 255]);
+    applyPosterize(rgba, 1, 1, 4);
+    // step = 85. round(40/85)*85 = 0*85=0, round(100/85)*85=1*85=85, round(180/85)*85=2*85=170
+    expect(rgba[0]).toBe(0);
+    expect(rgba[1]).toBe(85);
+    expect(rgba[2]).toBe(170);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 50]);
+    applyPosterize(rgba, 1, 1, 4);
+    expect(rgba[3]).toBe(50);
+  });
+});
+
+describe('applyVignette', () => {
+  it('strength=0: no change', () => {
+    const rgba = new Uint8ClampedArray([200, 200, 200, 255]);
+    applyVignette(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(200);
+  });
+
+  it('center pixel is less affected than corner pixels', () => {
+    // 3x3 image, all white
+    const rgba = new Uint8ClampedArray(9 * 4);
+    for (let i = 0; i < 9; i++) {
+      rgba[i * 4] = 255;
+      rgba[i * 4 + 1] = 255;
+      rgba[i * 4 + 2] = 255;
+      rgba[i * 4 + 3] = 255;
+    }
+    applyVignette(rgba, 3, 3, 1.0);
+    // Center pixel (1,1) should be brighter than corner (0,0)
+    const center = rgba[4 * 4]; // pixel index 4
+    const corner = rgba[0];     // pixel index 0
+    expect(center).toBeGreaterThan(corner);
+  });
+
+  it('strength=1: corners are significantly darkened', () => {
+    const rgba = new Uint8ClampedArray([255, 255, 255, 255]);
+    // 1x1 image: the single pixel is at center, radius=0, factor=1
+    applyVignette(rgba, 1, 1, 1.0);
+    // For 1x1, cx=0.5,cy=0.5, pixel at (0,0), dx=-0.5,dy=-0.5, dist=0.707, maxDist=0.707, radius=1, factor=1-1*1=0
+    expect(rgba[0]).toBe(0);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      200, 200, 200, 50,
+      200, 200, 200, 50,
+      200, 200, 200, 50,
+      200, 200, 200, 50,
+    ]);
+    applyVignette(rgba, 2, 2, 0.5);
+    for (let i = 0; i < 4; i++) {
+      expect(rgba[i * 4 + 3]).toBe(50);
+    }
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -499,6 +499,58 @@ export function applyColorMap(
 }
 
 /**
+ * Reduces the number of color levels per RGB channel (posterize effect).
+ * Each channel is quantized to the given number of levels (2~256).
+ * Alpha channel is not modified.
+ */
+export function applyPosterize(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  levels: number,
+): void {
+  if (levels < 2 || levels >= 256) return;
+  const step = 255 / (levels - 1);
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = Math.round(Math.round(rgba[off] / step) * step);
+    rgba[off + 1] = Math.round(Math.round(rgba[off + 1] / step) * step);
+    rgba[off + 2] = Math.round(Math.round(rgba[off + 2] / step) * step);
+  }
+}
+
+/**
+ * Applies a vignette effect: darkens pixels progressively from center to edges.
+ * strength controls intensity (0=none, 1=full darkening at corners).
+ * Formula: factor = 1 - strength * radius^2, where radius is normalized distance from center.
+ * Alpha channel is not modified.
+ */
+export function applyVignette(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  strength: number,
+): void {
+  if (strength === 0) return;
+  const cx = width / 2;
+  const cy = height / 2;
+  const maxDist = Math.sqrt(cx * cx + cy * cy);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      const radius = Math.sqrt(dx * dx + dy * dy) / maxDist;
+      const factor = Math.max(0, 1 - strength * radius * radius);
+      const off = (y * width + x) * 4;
+      rgba[off]     = Math.round(rgba[off] * factor);
+      rgba[off + 1] = Math.round(rgba[off + 1] * factor);
+      rgba[off + 2] = Math.round(rgba[off + 2] * factor);
+    }
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -198,6 +198,10 @@ export interface JP2LayerOptions {
   grayscale?: boolean;
   /** 단일 밴드 데이터에 적용할 색상 룩업 테이블 (길이 256 배열, 각 요소 [R, G, B]). 밴드 수 > 1이면 무시 */
   colorMap?: Array<[number, number, number]>;
+  /** 포스터라이즈 색상 레벨 수 (2~256, 기본값: 0 = 비활성). 각 RGB 채널의 색상 단계를 제한 */
+  posterize?: number;
+  /** 비네트 효과 강도 (0~1, 기본값: 0 = 비활성). 이미지 가장자리를 점진적으로 어둡게 처리 */
+  vignette?: number;
 }
 
 export interface JP2LayerResult {
@@ -352,6 +356,8 @@ export async function createJP2TileLayer(
     : undefined;
   // colorMap takes priority over grayscale for single-band images
   const grayscale = options?.grayscale;
+  const posterize = options?.posterize;
+  const vignette = options?.vignette;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -511,6 +517,14 @@ export async function createJP2TileLayer(
 
           if (sepia != null && sepia !== 0) {
             applySepia(decoded.data, decoded.width, decoded.height, sepia);
+          }
+
+          if (posterize != null && posterize >= 2 && posterize < 256) {
+            applyPosterize(decoded.data, decoded.width, decoded.height, posterize);
+          }
+
+          if (vignette != null && vignette > 0) {
+            applyVignette(decoded.data, decoded.width, decoded.height, vignette);
           }
 
           if (colorMapLUT && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- **posterize**: `JP2LayerOptions.posterize` (2~256) — 각 RGB 채널의 색상 레벨 수를 제한하여 포스터라이즈 효과 적용
- **vignette**: `JP2LayerOptions.vignette` (0~1) — 이미지 가장자리를 점진적으로 어둡게 처리하는 비네트 효과 적용
- 단위 테스트 추가 (posterize 4건, vignette 4건)

closes #170
closes #171

## Test plan
- [x] `npm test` 356 tests 전체 통과
- [ ] Reviewer: applyPosterize/applyVignette 로직 검토
- [ ] Tester: E2E 테스트에서 posterize/vignette 옵션 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)