### PR TITLE
feat(api): add edgeDetect and emboss options (#174, #175)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -841,5 +841,68 @@ describe('applyVignette', () => {
     for (let i = 0; i < 4; i++) {
       expect(rgba[i * 4 + 3]).toBe(50);
     }
+  });
+});
+
+describe('applyEdgeDetect', () => {
+  it('uniform image produces zero output', () => {
+    const rgba = new Uint8ClampedArray(9 * 4);
+    for (let i = 0; i < 9; i++) {
+      rgba[i * 4] = rgba[i * 4 + 1] = rgba[i * 4 + 2] = 100;
+      rgba[i * 4 + 3] = 255;
+    }
+    applyEdgeDetect(rgba, 3, 3);
+    const center = 4 * 4;
+    expect(rgba[center]).toBe(0);
+    expect(rgba[center + 1]).toBe(0);
+    expect(rgba[center + 2]).toBe(0);
+  });
+
+  it('detects edge at center pixel', () => {
+    const rgba = new Uint8ClampedArray(9 * 4);
+    for (let i = 0; i < 9; i++) rgba[i * 4 + 3] = 255;
+    rgba[4 * 4] = rgba[4 * 4 + 1] = rgba[4 * 4 + 2] = 255;
+    applyEdgeDetect(rgba, 3, 3);
+    const center = 4 * 4;
+    expect(rgba[center]).toBe(255);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 50]);
+    applyEdgeDetect(rgba, 1, 1);
+    expect(rgba[3]).toBe(50);
+  });
+});
+
+describe('applyEmboss', () => {
+  it('uniform image: kernel sum applied with 128 offset', () => {
+    const rgba = new Uint8ClampedArray(9 * 4);
+    for (let i = 0; i < 9; i++) {
+      rgba[i * 4] = rgba[i * 4 + 1] = rgba[i * 4 + 2] = 100;
+      rgba[i * 4 + 3] = 255;
+    }
+    applyEmboss(rgba, 3, 3);
+    const center = 4 * 4;
+    // kernel weights sum=1, so 100*1+128=228
+    expect(rgba[center]).toBe(228);
+  });
+
+  it('produces different values for top-left vs bottom-right on gradient', () => {
+    // 3x3 gradient: top-left dark, bottom-right bright
+    const rgba = new Uint8ClampedArray(9 * 4);
+    const values = [50, 55, 60, 55, 64, 70, 60, 70, 80];
+    for (let i = 0; i < 9; i++) {
+      rgba[i * 4] = rgba[i * 4 + 1] = rgba[i * 4 + 2] = values[i];
+      rgba[i * 4 + 3] = 255;
+    }
+    applyEmboss(rgba, 3, 3);
+    // Top-left and bottom-right should have different emboss values
+    expect(rgba[0]).not.toBe(rgba[8 * 4]);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 50]);
+    applyEmboss(rgba, 1, 1);
+    expect(rgba[3]).toBe(50);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -551,6 +551,70 @@ export function applyVignette(
 }
 
 /**
+ * Applies Laplacian edge detection to RGBA data.
+ * Kernel: [0,-1,0; -1,4,-1; 0,-1,0].
+ * Alpha channel is not modified.
+ */
+export function applyEdgeDetect(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+): void {
+  const pixelCount = width * height;
+  const tmp = new Uint8ClampedArray(pixelCount * 4);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const off = (y * width + x) * 4;
+      for (let c = 0; c < 3; c++) {
+        const center = rgba[off + c] * 4;
+        const top    = y > 0          ? rgba[((y - 1) * width + x) * 4 + c] : rgba[off + c];
+        const bottom = y < height - 1 ? rgba[((y + 1) * width + x) * 4 + c] : rgba[off + c];
+        const left   = x > 0          ? rgba[(y * width + x - 1) * 4 + c] : rgba[off + c];
+        const right  = x < width - 1  ? rgba[(y * width + x + 1) * 4 + c] : rgba[off + c];
+        tmp[off + c] = Math.max(0, Math.min(255, center - top - bottom - left - right));
+      }
+      tmp[off + 3] = rgba[off + 3];
+    }
+  }
+  rgba.set(tmp);
+}
+
+/**
+ * Applies emboss effect to RGBA data.
+ * Kernel: [-2,-1,0; -1,1,1; 0,1,2]. Result offset by 128.
+ * Alpha channel is not modified.
+ */
+export function applyEmboss(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+): void {
+  const pixelCount = width * height;
+  const tmp = new Uint8ClampedArray(pixelCount * 4);
+  // Kernel weights indexed by (ky+1)*3+(kx+1)
+  const kernel = [-2, -1, 0, -1, 1, 1, 0, 1, 2];
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const off = (y * width + x) * 4;
+      for (let c = 0; c < 3; c++) {
+        let sum = 0;
+        for (let ky = -1; ky <= 1; ky++) {
+          for (let kx = -1; kx <= 1; kx++) {
+            const ny = Math.max(0, Math.min(height - 1, y + ky));
+            const nx = Math.max(0, Math.min(width - 1, x + kx));
+            const w = kernel[(ky + 1) * 3 + (kx + 1)];
+            sum += rgba[(ny * width + nx) * 4 + c] * w;
+          }
+        }
+        tmp[off + c] = Math.max(0, Math.min(255, sum + 128));
+      }
+      tmp[off + 3] = rgba[off + 3];
+    }
+  }
+  rgba.set(tmp);
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -202,6 +202,10 @@ export interface JP2LayerOptions {
   posterize?: number;
   /** 비네트 효과 강도 (0~1, 기본값: 0 = 비활성). 이미지 가장자리를 점진적으로 어둡게 처리 */
   vignette?: number;
+  /** Laplacian 엣지 검출 필터 적용 (기본값: false) */
+  edgeDetect?: boolean;
+  /** 엠보스(양각) 효과 적용 (기본값: false) */
+  emboss?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -358,6 +362,8 @@ export async function createJP2TileLayer(
   const grayscale = options?.grayscale;
   const posterize = options?.posterize;
   const vignette = options?.vignette;
+  const edgeDetect = options?.edgeDetect;
+  const emboss = options?.emboss;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -525,6 +531,14 @@ export async function createJP2TileLayer(
 
           if (vignette != null && vignette > 0) {
             applyVignette(decoded.data, decoded.width, decoded.height, vignette);
+          }
+
+          if (edgeDetect) {
+            applyEdgeDetect(decoded.data, decoded.width, decoded.height);
+          }
+
+          if (emboss) {
+            applyEmboss(decoded.data, decoded.width, decoded.height);
           }
 
           if (colorMapLUT && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `edgeDetect: true` 옵션 추가: Laplacian 커널 [0,-1,0; -1,4,-1; 0,-1,0]을 이용한 엣지 검출 필터
- `emboss: true` 옵션 추가: 엠보스 커널 [-2,-1,0; -1,1,1; 0,1,2] + 128 오프셋 양각 효과
- 효과 체인: posterize → vignette → edgeDetect → emboss 순서로 적용

closes #174
closes #175

## Test plan
- [x] `applyEdgeDetect` 단위 테스트 3개 (uniform=0, edge detection, alpha 보존)
- [x] `applyEmboss` 단위 테스트 3개 (uniform+128 offset, gradient 효과, alpha 보존)
- [x] `npm test` 전체 통과 (362 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)