### PR TITLE
docs(changelog): add Sprint 50 entries for edgeDetect and emboss options (#174, #175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 50
+
+### Added
+- **`JP2LayerOptions.edgeDetect`**: Laplacian 엣지 검출 필터 옵션 추가 (closes #174, PR #176)
+  - 타입: `boolean`, 기본값: `false` (비활성)
+  - 커널: [0,-1,0; -1,4,-1; 0,-1,0]. 경계선을 강조하고 내부 균일 영역은 어두워짐
+  - `pixel-conversion.ts`의 `applyEdgeDetect()` 함수로 처리
+- **`JP2LayerOptions.emboss`**: 엠보스(양각) 효과 옵션 추가 (closes #175, PR #176)
+  - 타입: `boolean`, 기본값: `false` (비활성)
+  - 커널: [-2,-1,0; -1,1,1; 0,1,2] + 128 오프셋. 빛이 왼쪽 상단에서 비추는 입체감 표현
+  - `pixel-conversion.ts`의 `applyEmboss()` 함수로 처리
+  - 적용 순서: posterize → vignette → edgeDetect → emboss
+
+---
+
 ## [Unreleased] — Sprint 47
 
 ### Added

--- a/src/source.ts
+++ b/src/source.ts
@@ -202,9 +202,19 @@ export interface JP2LayerOptions {
   posterize?: number;
   /** 비네트 효과 강도 (0~1, 기본값: 0 = 비활성). 이미지 가장자리를 점진적으로 어둡게 처리 */
   vignette?: number;
-  /** Laplacian 엣지 검출 필터 적용 (기본값: false) */
+  /**
+   * Laplacian 엣지 검출 필터 적용 여부.
+   * 커널: [0,-1,0; -1,4,-1; 0,-1,0]. 경계선을 강조하고 내부 균일 영역은 어두워짐.
+   * 타입: `boolean`, 기본값: `false` (비활성)
+   * 적용 순서: posterize → vignette → edgeDetect → emboss
+   */
   edgeDetect?: boolean;
-  /** 엠보스(양각) 효과 적용 (기본값: false) */
+  /**
+   * 엠보스(양각) 효과 적용 여부.
+   * 커널: [-2,-1,0; -1,1,1; 0,1,2] + 128 오프셋. 빛이 왼쪽 상단에서 비추는 입체감 표현.
+   * 타입: `boolean`, 기본값: `false` (비활성)
+   * 적용 순서: posterize → vignette → edgeDetect → emboss
+   */
   emboss?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 50 항목 추가 (edgeDetect, emboss 옵션)
- `JP2LayerOptions.edgeDetect` 및 `emboss` JSDoc 상세 보강

closes #174
closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)