### PR TITLE
feat(api): add colorBalance and exposure options (#182, #183)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -996,6 +996,70 @@ describe('applyChannelSwap', () => {
   it('alpha channel unchanged', () => {
     const rgba = new Uint8ClampedArray([100, 150, 200, 50]);
     applyChannelSwap(rgba, 1, 1, [2, 1, 0]);
+    expect(rgba[3]).toBe(50);
+  });
+});
+
+describe('applyColorBalance', () => {
+  it('adds offset to each channel independently', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyColorBalance(rgba, 1, 1, [30, -10, -20]);
+    expect(rgba[0]).toBe(130);
+    expect(rgba[1]).toBe(140);
+    expect(rgba[2]).toBe(180);
+  });
+
+  it('clamps to 0-255', () => {
+    const rgba = new Uint8ClampedArray([10, 250, 128, 255]);
+    applyColorBalance(rgba, 1, 1, [-20, 20, 0]);
+    expect(rgba[0]).toBe(0);   // clamped
+    expect(rgba[1]).toBe(255); // clamped
+    expect(rgba[2]).toBe(128);
+  });
+
+  it('no-op when all zeros', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyColorBalance(rgba, 1, 1, [0, 0, 0]);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 50]);
+    applyColorBalance(rgba, 1, 1, [10, 10, 10]);
+    expect(rgba[3]).toBe(50);
+  });
+});
+
+describe('applyExposure', () => {
+  it('multiplies RGB channels by exposure factor', () => {
+    const rgba = new Uint8ClampedArray([100, 200, 50, 255]);
+    applyExposure(rgba, 1, 1, 1.5);
+    expect(rgba[0]).toBe(150);
+    expect(rgba[1]).toBe(255); // clamped from 300
+    expect(rgba[2]).toBe(75);
+  });
+
+  it('darkens with exposure < 1', () => {
+    const rgba = new Uint8ClampedArray([100, 200, 50, 255]);
+    applyExposure(rgba, 1, 1, 0.5);
+    expect(rgba[0]).toBe(50);
+    expect(rgba[1]).toBe(100);
+    expect(rgba[2]).toBe(25);
+  });
+
+  it('no-op when exposure is 1.0', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyExposure(rgba, 1, 1, 1.0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 50]);
+    applyExposure(rgba, 1, 1, 2.0);
     expect(rgba[3]).toBe(50);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -681,6 +681,51 @@ export function applyChannelSwap(
 }
 
 /**
+ * Adjusts RGB channels independently: out_ch = clamp(in_ch + offset_ch, 0, 255).
+ * Each element of the balance tuple is clamped to -255~255.
+ * Alpha channel is not modified.
+ */
+export function applyColorBalance(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  balance: [number, number, number],
+): void {
+  const rOff = Math.max(-255, Math.min(255, Math.round(balance[0])));
+  const gOff = Math.max(-255, Math.min(255, Math.round(balance[1])));
+  const bOff = Math.max(-255, Math.min(255, Math.round(balance[2])));
+  if (rOff === 0 && gOff === 0 && bOff === 0) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = rgba[off] + rOff;
+    rgba[off + 1] = rgba[off + 1] + gOff;
+    rgba[off + 2] = rgba[off + 2] + bOff;
+  }
+}
+
+/**
+ * Applies exposure (multiplicative brightness) to RGB channels: out = clamp(in * exposure, 0, 255).
+ * exposure=1.0: no change, >1.0: brighter, <1.0: darker.
+ * Alpha channel is not modified.
+ */
+export function applyExposure(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  exposure: number,
+): void {
+  if (exposure === 1.0) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = Math.round(Math.max(0, Math.min(255, rgba[off] * exposure)));
+    rgba[off + 1] = Math.round(Math.max(0, Math.min(255, rgba[off + 1] * exposure)));
+    rgba[off + 2] = Math.round(Math.max(0, Math.min(255, rgba[off + 2] * exposure)));
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -210,6 +210,10 @@ export interface JP2LayerOptions {
   pixelate?: number;
   /** RGB 채널 순서 변경. [소스R인덱스, 소스G인덱스, 소스B인덱스] (0=R, 1=G, 2=B). 예: [2,1,0]은 BGR→RGB 변환 */
   channelSwap?: [number, number, number];
+  /** RGB 채널별 색상 균형 조정 [R, G, B] (각 -255 ~ 255). 각 채널에 가산 적용 */
+  colorBalance?: [number, number, number];
+  /** 승산 방식 밝기 보정 (기본값: 1.0, 변화 없음). >1.0 밝아짐, <1.0 어두워짐 */
+  exposure?: number;
 }
 
 export interface JP2LayerResult {
@@ -370,6 +374,8 @@ export async function createJP2TileLayer(
   const emboss = options?.emboss;
   const pixelate = options?.pixelate;
   const channelSwap = options?.channelSwap;
+  const colorBalance = options?.colorBalance;
+  const exposure = options?.exposure;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -553,6 +559,14 @@ export async function createJP2TileLayer(
 
           if (channelSwap) {
             applyChannelSwap(decoded.data, decoded.width, decoded.height, channelSwap);
+          }
+
+          if (colorBalance) {
+            applyColorBalance(decoded.data, decoded.width, decoded.height, colorBalance);
+          }
+
+          if (exposure != null && exposure !== 1.0) {
+            applyExposure(decoded.data, decoded.width, decoded.height, exposure);
           }
 
           if (colorMapLUT && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `colorBalance` 옵션 추가: RGB 채널별 독립적 색상 균형 조정 (`[R, G, B]`, 각 -255~255 가산)
- `exposure` 옵션 추가: 승산 방식 밝기 보정 (1.0=변화 없음, >1.0 밝아짐, <1.0 어두워짐)
- 적용 순서: channelSwap → colorBalance → exposure (이슈 명세 준수)

closes #182
closes #183

## Test plan
- [x] `applyColorBalance` 단위 테스트 4건 통과
- [x] `applyExposure` 단위 테스트 4건 통과
- [x] 전체 테스트 스위트 379건 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)