### PR TITLE
feat(api): add levels option for pixel input level remapping

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1060,6 +1060,46 @@ describe('applyExposure', () => {
   it('alpha channel unchanged', () => {
     const rgba = new Uint8ClampedArray([100, 150, 200, 50]);
     applyExposure(rgba, 1, 1, 2.0);
+    expect(rgba[3]).toBe(50);
+  });
+});
+
+describe('applyLevels', () => {
+  it('no change when inputMin=0 and inputMax=255', () => {
+    const rgba = new Uint8ClampedArray([50, 100, 200, 255]);
+    applyLevels(rgba, 1, 1, 0, 255);
+    expect(rgba[0]).toBe(50);
+    expect(rgba[1]).toBe(100);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('remaps [50, 200] to [0, 255]', () => {
+    const rgba = new Uint8ClampedArray([50, 125, 200, 255]);
+    applyLevels(rgba, 1, 1, 50, 200);
+    expect(rgba[0]).toBe(0);
+    expect(rgba[1]).toBe(128);
+    expect(rgba[2]).toBe(255);
+  });
+
+  it('clamps values below inputMin to 0', () => {
+    const rgba = new Uint8ClampedArray([10, 10, 10, 255]);
+    applyLevels(rgba, 1, 1, 50, 200);
+    expect(rgba[0]).toBe(0);
+    expect(rgba[1]).toBe(0);
+    expect(rgba[2]).toBe(0);
+  });
+
+  it('clamps values above inputMax to 255', () => {
+    const rgba = new Uint8ClampedArray([250, 250, 250, 255]);
+    applyLevels(rgba, 1, 1, 50, 200);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(255);
+    expect(rgba[2]).toBe(255);
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 50]);
+    applyLevels(rgba, 1, 1, 50, 200);
     expect(rgba[3]).toBe(50);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -726,6 +726,29 @@ export function applyExposure(
 }
 
 /**
+ * Remaps pixel input levels: maps [inputMin, inputMax] → [0, 255] linearly.
+ * Values below inputMin become 0, values above inputMax become 255.
+ * Alpha channel is not modified.
+ */
+export function applyLevels(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  inputMin: number,
+  inputMax: number,
+): void {
+  if (inputMin === 0 && inputMax === 255) return;
+  const range = inputMax - inputMin || 1;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = Math.round(Math.max(0, Math.min(255, (rgba[off] - inputMin) * 255 / range)));
+    rgba[off + 1] = Math.round(Math.max(0, Math.min(255, (rgba[off + 1] - inputMin) * 255 / range)));
+    rgba[off + 2] = Math.round(Math.max(0, Math.min(255, (rgba[off + 2] - inputMin) * 255 / range)));
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -214,6 +214,8 @@ export interface JP2LayerOptions {
   colorBalance?: [number, number, number];
   /** 승산 방식 밝기 보정 (기본값: 1.0, 변화 없음). >1.0 밝아짐, <1.0 어두워짐 */
   exposure?: number;
+  /** 픽셀 입력 레벨 범위 조정. inputMin~inputMax를 0~255로 선형 재매핑 (기본값: {inputMin: 0, inputMax: 255}) */
+  levels?: { inputMin?: number; inputMax?: number };
 }
 
 export interface JP2LayerResult {
@@ -376,6 +378,7 @@ export async function createJP2TileLayer(
   const channelSwap = options?.channelSwap;
   const colorBalance = options?.colorBalance;
   const exposure = options?.exposure;
+  const levels = options?.levels;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -567,6 +570,12 @@ export async function createJP2TileLayer(
 
           if (exposure != null && exposure !== 1.0) {
             applyExposure(decoded.data, decoded.width, decoded.height, exposure);
+          }
+
+          if (levels) {
+            const inputMin = levels.inputMin ?? 0;
+            const inputMax = levels.inputMax ?? 255;
+            applyLevels(decoded.data, decoded.width, decoded.height, inputMin, inputMax);
           }
 
           if (colorMapLUT && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `JP2LayerOptions`에 `levels` 옵션 추가 (`inputMin`, `inputMax`)
- `applyLevels()` 함수로 [inputMin, inputMax] → [0, 255] 선형 재매핑 구현
- 픽셀 처리 파이프라인에서 exposure 이후 단계에 통합

closes #186

## Test plan
- [x] `applyLevels` 단위 테스트 5개 추가 (no-op, 재매핑, 클램핑, 알파 보존)
- [x] `npm test` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)