### PR TITLE
docs: update CHANGELOG and README for sprint 52-53 (levels, noise options)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 53
+
+### Added
+- **`JP2LayerOptions.levels`**: 픽셀 입력 레벨 범위 재매핑 옵션 추가 (closes #186, PR #188)
+  - 타입: `{ inputMin?: number; inputMax?: number }`, 기본값: `{ inputMin: 0, inputMax: 255 }`
+  - `[inputMin, inputMax]` 범위를 `[0, 255]`로 선형 재매핑, 범위 밖 값은 클램핑
+  - `pixel-conversion.ts`의 `applyLevels()` 함수로 처리
+  - 적용 순서: ...exposure → levels → noise → colorMap...
+- **`JP2LayerOptions.noise`**: 랜덤 노이즈 효과 옵션 추가 (closes #187, PR #189)
+  - 타입: `number` (0~255), 기본값: `0` (노이즈 없음)
+  - 각 RGB 채널에 `[-noise, +noise]` 균등 분포 랜덤값 가산, 결과 0~255 클램핑
+  - 알파 채널 미변경
+  - `pixel-conversion.ts`의 `applyNoise()` 함수로 처리
+  - 적용 순서: ...levels → noise → colorMap...
+
+---
+
 ## [Unreleased] — Sprint 52
 
 ### Added
-- **`JP2LayerOptions.colorBalance`**: RGB 채널별 색상 균형 조정 옵션 추가 (closes #182, PR #184)
-  - 타입: `[number, number, number]` (R/G/B 채널 오프셋, 각 -255 ~ 255)
-  - 각 채널에 오프셋을 가산하여 색상 균형을 조정. 클램핑은 `Uint8ClampedArray`가 자동 처리
+- **`JP2LayerOptions.colorBalance`**: RGB 채널별 독립 색상 균형 조정 옵션 추가 (closes #182, PR #184)
+  - 타입: `[number, number, number]` (R, G, B 오프셋, 각 -255 ~ 255), 기본값: `undefined`
+  - 각 채널에 오프셋 가산, 결과 0~255 클램핑
   - `pixel-conversion.ts`의 `applyColorBalance()` 함수로 처리
 - **`JP2LayerOptions.exposure`**: 승산 방식 밝기 보정 옵션 추가 (closes #183, PR #184)
-  - 타입: `number` (기본값: `1.0`, 변화 없음)
-  - `1.0` 초과 시 밝아짐, `1.0` 미만 시 어두워짐. 각 픽셀에 승산 후 0~255 클램핑
+  - 타입: `number`, 기본값: `1.0` (변화 없음)
+  - `>1.0` 밝아짐, `<1.0` 어두워짐. 각 RGB 채널에 `out = clamp(in * exposure, 0, 255)` 적용
   - `pixel-conversion.ts`의 `applyExposure()` 함수로 처리
-  - 적용 순서: ...channelSwap → colorBalance → exposure
+  - 적용 순서: ...channelSwap → colorBalance → exposure → levels → colorMap...
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `nodata` | `number` | `undefined` | 투명하게 처리할 픽셀 값. 지정된 값과 일치하는 픽셀의 알파 채널을 0으로 설정하여 투명하게 렌더링 |
 | `nodataTolerance` | `number` | `0` | nodata 값 매칭 허용 오차. `\|pixel - nodata\| <= tolerance` 조건으로 매칭. 16비트→8비트 양자화 오차 보정에 유용 |
 | `gamma` | `number` | `1.0` | 픽셀 감마 보정 값. 1보다 크면 밝아지고, 1보다 작으면 어두워짐. `out = 255 × (in/255)^(1/gamma)` 공식 적용 |
+| `brightness` | `number` | `0` | 픽셀 밝기 조정 (-1 ~ 1). `out = in + brightness × 255` 공식 적용. 양수면 밝아지고 음수면 어두워짐 |
+| `contrast` | `number` | `1.0` | 픽셀 대비 조정. `out = (in - 128) × contrast + 128`. 1보다 크면 대비 증가, 0~1이면 감소 |
+| `saturation` | `number` | `1.0` | 픽셀 채도 조정. 0이면 흑백, 1보다 크면 채도 증가 |
+| `hue` | `number` | `0` | 색조 회전 각도 (도). 180이면 보색 |
+| `invert` | `boolean` | `false` | 픽셀 색상 반전. `out = 255 - in` |
+| `threshold` | `number` | `undefined` | luminance 기준 임계값 이진화 (0~255). 지정 시 흑백 변환 |
+| `colorize` | `[r, g, b]` | `undefined` | 그레이스케일 이미지 색상화 (각 0~255). luminance 기반 착색 |
+| `sharpen` | `number` | `0` | 언샤프 마스킹 선명화 강도 (0.0~1.0). 3×3 가우시안 블러 기반 |
+| `blur` | `number` | `0` | 가우시안 블러 스무딩 적용 횟수. 3×3 커널 반복 적용 |
+| `sepia` | `number` | `0` | 세피아 톤 효과 강도 (0~1). 0=원본, 1=완전 세피아 |
+| `grayscale` | `boolean` | `false` | RGB 이미지를 그레이스케일로 변환. ITU-R BT.709 가중치 사용 |
+| `colorMap` | `Array<[r, g, b]>` | `undefined` | 단채널 데이터에 적용할 256엔트리 컬러 룩업 테이블 |
+| `posterize` | `number` | `0` | 포스터라이즈 색상 레벨 수 (2~256). 각 RGB 채널의 색상 단계 제한 |
+| `vignette` | `number` | `0` | 비네트 효과 강도 (0~1). 이미지 가장자리를 점진적으로 어둡게 처리 |
+| `edgeDetect` | `boolean` | `false` | Laplacian 엣지 검출 필터 적용 |
+| `emboss` | `boolean` | `false` | 엠보스(양각) 효과 적용 |
+| `pixelate` | `number` | `undefined` | 픽셀화(블록 모자이크) 효과의 블록 크기 (px). 2 이상 시 활성화 |
+| `channelSwap` | `[r, g, b]` | `undefined` | RGB 채널 순서 변경. 예: `[2,1,0]`은 BGR→RGB 변환 |
+| `colorBalance` | `[r, g, b]` | `undefined` | RGB 채널별 색상 균형 조정 (각 -255~255). 각 채널에 가산 |
+| `exposure` | `number` | `1.0` | 승산 방식 밝기 보정. `>1.0` 밝아짐, `<1.0` 어두워짐. `out = clamp(in × exposure, 0, 255)` |
+| `levels` | `{ inputMin?: number; inputMax?: number }` | `{ inputMin: 0, inputMax: 255 }` | 픽셀 입력 레벨 범위 재매핑. `[inputMin, inputMax]` → `[0, 255]` 선형 재매핑, 범위 밖 값 클램핑 |
+| `noise` | `number` | `0` | 랜덤 노이즈 강도 (0~255). 각 RGB 채널에 `[-noise, +noise]` 균등 분포 랜덤값 가산 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- Sprint 53 CHANGELOG 항목 추가: `levels` (closes #186, PR #188), `noise` (closes #187, PR #189)
- Sprint 52 CHANGELOG 항목 추가: `colorBalance` (PR #184), `exposure` (PR #184)
- README 옵션 테이블에 누락된 픽셀 처리 옵션 전체 추가 (brightness, contrast, saturation, hue, invert, threshold, colorize, sharpen, blur, sepia, grayscale, colorMap, posterize, vignette, edgeDetect, emboss, pixelate, channelSwap, colorBalance, exposure, levels, noise)

## Test plan
- [ ] CHANGELOG 내용이 PR #188, #189 내용과 일치하는지 확인
- [ ] README 옵션 테이블이 `JP2LayerOptions` 인터페이스와 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)