### PR TITLE
feat(api): add levels option validation (#190)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, applyNoise } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1139,5 +1139,32 @@ describe('applyNoise', () => {
     const rgba = new Uint8ClampedArray([100, 150, 200, 77]);
     applyNoise(rgba, 1, 1, 50);
     expect(rgba[3]).toBe(77);
+  });
+});
+
+describe('validateLevels', () => {
+  it('returns values unchanged when valid', () => {
+    const result = validateLevels(50, 200);
+    expect(result).toEqual({ inputMin: 50, inputMax: 200, swapped: false });
+  });
+
+  it('clamps values to 0-255 range', () => {
+    const result = validateLevels(-10, 300);
+    expect(result).toEqual({ inputMin: 0, inputMax: 255, swapped: false });
+  });
+
+  it('swaps when inputMin > inputMax', () => {
+    const result = validateLevels(200, 50);
+    expect(result).toEqual({ inputMin: 50, inputMax: 200, swapped: true });
+  });
+
+  it('rounds fractional values', () => {
+    const result = validateLevels(10.7, 200.3);
+    expect(result).toEqual({ inputMin: 11, inputMax: 200, swapped: false });
+  });
+
+  it('handles equal values', () => {
+    const result = validateLevels(128, 128);
+    expect(result).toEqual({ inputMin: 128, inputMax: 128, swapped: false });
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -726,6 +726,25 @@ export function applyExposure(
 }
 
 /**
+ * Validates and normalizes levels input values.
+ * Clamps inputMin/inputMax to 0-255 range.
+ * If inputMin > inputMax, swaps them and returns swapped=true.
+ */
+export function validateLevels(
+  inputMin: number,
+  inputMax: number,
+): { inputMin: number; inputMax: number; swapped: boolean } {
+  let min = Math.max(0, Math.min(255, Math.round(inputMin)));
+  let max = Math.max(0, Math.min(255, Math.round(inputMax)));
+  let swapped = false;
+  if (min > max) {
+    [min, max] = [max, min];
+    swapped = true;
+  }
+  return { inputMin: min, inputMax: max, swapped };
+}
+
+/**
  * Remaps pixel input levels: maps [inputMin, inputMax] → [0, 255] linearly.
  * Values below inputMin become 0, values above inputMax become 255.
  * Alpha channel is not modified.

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, applyNoise } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -576,9 +576,11 @@ export async function createJP2TileLayer(
           }
 
           if (levels) {
-            const inputMin = levels.inputMin ?? 0;
-            const inputMax = levels.inputMax ?? 255;
-            applyLevels(decoded.data, decoded.width, decoded.height, inputMin, inputMax);
+            const validated = validateLevels(levels.inputMin ?? 0, levels.inputMax ?? 255);
+            if (validated.swapped) {
+              debugWarn(`levels.inputMin > levels.inputMax, swapping values`);
+            }
+            applyLevels(decoded.data, decoded.width, decoded.height, validated.inputMin, validated.inputMax);
           }
 
           if (noise != null && noise > 0) {


### PR DESCRIPTION
## Summary
- `validateLevels()` 함수 추가: inputMin/inputMax를 0-255 범위로 클램프, inputMin > inputMax 시 자동 스왑
- source.ts에서 levels 옵션 적용 전 validateLevels() 호출하여 유효성 검사
- 5개의 단위 테스트 추가 (정상값, 범위 클램프, 스왑, 반올림, 동일값)

## Test plan
- [x] `npm test` 통과 (393 tests)
- [ ] levels 옵션에 범위 밖 값 전달 시 클램프 확인
- [ ] inputMin > inputMax 전달 시 경고 로그 및 스왑 확인

closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)