### PR TITLE
feat(api): add noise max clipping and range docs (#191)

### DIFF
--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -750,7 +750,9 @@ export function applyLevels(
 
 /**
  * Adds random noise to RGB channels: out = clamp(in + random(-noise, +noise), 0, 255).
- * noise=0: no change. Alpha channel is not modified.
+ * noise=0: no change. Recommended range: 0~50 (higher values severely degrade image quality).
+ * Values above 255 are clipped to 255 at the caller level.
+ * Alpha channel is not modified.
  */
 export function applyNoise(
   rgba: Uint8ClampedArray,

--- a/src/source.ts
+++ b/src/source.ts
@@ -216,7 +216,7 @@ export interface JP2LayerOptions {
   exposure?: number;
   /** 픽셀 입력 레벨 범위 조정. inputMin~inputMax를 0~255로 선형 재매핑 (기본값: {inputMin: 0, inputMax: 255}) */
   levels?: { inputMin?: number; inputMax?: number };
-  /** 랜덤 노이즈 강도 (0~255, 기본값: 0). 각 RGB 채널에 [-noise, +noise] 균등 분포 랜덤값 가산 */
+  /** 랜덤 노이즈 강도 (0~255, 기본값: 0). 각 RGB 채널에 [-noise, +noise] 균등 분포 랜덤값 가산. 권장 범위: 0~50 (50 이상은 이미지 품질 저하가 심함). 255 초과 시 255로 클리핑 */
   noise?: number;
 }
 
@@ -582,7 +582,7 @@ export async function createJP2TileLayer(
           }
 
           if (noise != null && noise > 0) {
-            applyNoise(decoded.data, decoded.width, decoded.height, noise);
+            applyNoise(decoded.data, decoded.width, decoded.height, Math.min(noise, 255));
           }
 
           if (colorMapLUT && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- noise 값 255 초과 시 255로 클리핑하는 로직 추가
- JSDoc에 권장 범위(0~50) 및 클리핑 동작 문서화

## Test plan
- [x] `npm test` 통과 (388 tests)
- [ ] noise=300 전달 시 255로 클리핑되어 정상 동작 확인

closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)