### PR TITLE
feat(api): add tint option for color overlay (#193)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1166,5 +1166,47 @@ describe('validateLevels', () => {
   it('handles equal values', () => {
     const result = validateLevels(128, 128);
     expect(result).toEqual({ inputMin: 128, inputMax: 128, swapped: false });
+  });
+});
+
+describe('applyTint', () => {
+  it('no-op when strength=0', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyTint(rgba, 1, 1, 255, 0, 0, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('full tint when strength=1', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyTint(rgba, 1, 1, 255, 0, 0, 1);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(0);
+    expect(rgba[2]).toBe(0);
+  });
+
+  it('blends at strength=0.5 (default)', () => {
+    const rgba = new Uint8ClampedArray([100, 200, 0, 255]);
+    applyTint(rgba, 1, 1, 0, 0, 100);
+    // default strength=0.5: result = original*0.5 + tint*0.5
+    expect(rgba[0]).toBe(50);   // 100*0.5 + 0*0.5
+    expect(rgba[1]).toBe(100);  // 200*0.5 + 0*0.5
+    expect(rgba[2]).toBe(50);   // 0*0.5 + 100*0.5
+  });
+
+  it('alpha channel unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 77]);
+    applyTint(rgba, 1, 1, 255, 0, 0, 0.5);
+    expect(rgba[3]).toBe(77);
+  });
+
+  it('clamps strength to 0-1 range', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyTint(rgba, 1, 1, 255, 0, 0, 2.0);
+    // strength clamped to 1.0
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(0);
+    expect(rgba[2]).toBe(0);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -790,6 +790,32 @@ export function applyNoise(
 }
 
 /**
+ * Applies a tint color overlay by blending original pixels with the tint color.
+ * Formula: result = original * (1 - strength) + tint * strength.
+ * strength defaults to 0.5 if not provided. Alpha channel is not modified.
+ */
+export function applyTint(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  r: number,
+  g: number,
+  b: number,
+  strength: number = 0.5,
+): void {
+  if (strength === 0) return;
+  const s = Math.max(0, Math.min(1, strength));
+  const inv = 1 - s;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = Math.round(rgba[off] * inv + r * s);
+    rgba[off + 1] = Math.round(rgba[off + 1] * inv + g * s);
+    rgba[off + 2] = Math.round(rgba[off + 2] * inv + b * s);
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -218,6 +218,8 @@ export interface JP2LayerOptions {
   levels?: { inputMin?: number; inputMax?: number };
   /** 랜덤 노이즈 강도 (0~255, 기본값: 0). 각 RGB 채널에 [-noise, +noise] 균등 분포 랜덤값 가산. 권장 범위: 0~50 (50 이상은 이미지 품질 저하가 심함). 255 초과 시 255로 클리핑 */
   noise?: number;
+  /** 이미지 전체에 색조 오버레이 적용 [R, G, B, strength] (strength: 0~1, 기본값 0.5). 원본 색상과 지정 색상을 블렌딩 */
+  tint?: [number, number, number, number?];
 }
 
 export interface JP2LayerResult {
@@ -382,6 +384,7 @@ export async function createJP2TileLayer(
   const exposure = options?.exposure;
   const levels = options?.levels;
   const noise = options?.noise;
+  const tint = options?.tint;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -585,6 +588,10 @@ export async function createJP2TileLayer(
 
           if (noise != null && noise > 0) {
             applyNoise(decoded.data, decoded.width, decoded.height, Math.min(noise, 255));
+          }
+
+          if (tint) {
+            applyTint(decoded.data, decoded.width, decoded.height, tint[0], tint[1], tint[2], tint[3]);
           }
 
           if (colorMapLUT && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- `applyTint()` 함수 추가: 원본 색상과 지정 색상을 strength 비율로 블렌딩
- `JP2LayerOptions.tint` 옵션 추가: `[R, G, B, strength?]` (strength 기본값 0.5)
- 파이프라인에서 noise 이후에 적용
- 5개 단위 테스트 추가

## Test plan
- [x] `npm test` 통과 (393 tests)
- [ ] tint=[255, 0, 0, 0.3] 적용 시 붉은 색조 오버레이 확인
- [ ] strength=0 시 원본 유지 확인

closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)