### PR TITLE
docs: update CHANGELOG and README for sprint 54 (tint, levels, noise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 54
+
+### Added
+- **`JP2LayerOptions.tint`**: 색조 오버레이 블렌딩 옵션 추가 (closes #193, PR #196)
+  - 타입: `[r: number, g: number, b: number, strength?: number]`, 기본값: `undefined`
+  - 원본 색상과 지정 색상을 `strength` 비율로 블렌딩. `strength` 기본값: `0.5`
+  - 예: `[255, 0, 0, 0.3]`은 붉은 색조 30% 오버레이
+  - `pixel-conversion.ts`의 `applyTint()` 함수로 처리
+  - 적용 순서: ...noise → tint → colorMap...
+- **`levels` 옵션 유효성 검사 강화**: `validateLevels()` 함수 추가 (closes #190, PR #194)
+  - `inputMin`/`inputMax`를 0~255 범위로 자동 클램프
+  - `inputMin > inputMax` 시 경고 로그 출력 후 자동 스왑
+  - `pixel-conversion.ts`의 `validateLevels()` 함수로 처리, `source.ts`에서 적용 전 호출
+- **`noise` 최대값 클리핑 및 권장 범위 문서화** (closes #191, PR #195)
+  - noise 값 255 초과 시 255로 자동 클리핑
+  - JSDoc에 권장 범위(0~50) 및 클리핑 동작 명시
+
+---
+
 ## [Unreleased] — Sprint 53
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `colorBalance` | `[r, g, b]` | `undefined` | RGB 채널별 색상 균형 조정 (각 -255~255). 각 채널에 가산 |
 | `exposure` | `number` | `1.0` | 승산 방식 밝기 보정. `>1.0` 밝아짐, `<1.0` 어두워짐. `out = clamp(in × exposure, 0, 255)` |
 | `levels` | `{ inputMin?: number; inputMax?: number }` | `{ inputMin: 0, inputMax: 255 }` | 픽셀 입력 레벨 범위 재매핑. `[inputMin, inputMax]` → `[0, 255]` 선형 재매핑, 범위 밖 값 클램핑 |
-| `noise` | `number` | `0` | 랜덤 노이즈 강도 (0~255). 각 RGB 채널에 `[-noise, +noise]` 균등 분포 랜덤값 가산 |
+| `noise` | `number` | `0` | 랜덤 노이즈 강도 (0~255, 권장 0~50). 각 RGB 채널에 `[-noise, +noise]` 균등 분포 랜덤값 가산. 255 초과 시 255로 클리핑 |
+| `tint` | `[r, g, b, strength?]` | `undefined` | 색조 오버레이 블렌딩. `[R, G, B, strength]`로 지정, `strength` 기본값 `0.5` (0=원본, 1=단색). 예: `[255, 0, 0, 0.3]`은 붉은 색조 30% 오버레이 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 54 항목 추가: `tint` (PR #196), `levels` 유효성 검사 (PR #194), `noise` 클리핑 (PR #195)
- README 옵션 테이블에 `tint` 옵션 추가, `noise` 설명에 권장 범위 및 클리핑 정보 보완

## 반영된 PR
- #194: levels 옵션 유효성 검사 (`validateLevels()`, 자동 클램프/스왑)
- #195: noise 최대값 클리핑 및 권장 범위 문서화
- #196: tint 색조 오버레이 블렌딩 옵션 추가
- #192: sprint 52-53 문서 업데이트 (이전 반영 확인)

## Test plan
- [ ] CHANGELOG Sprint 54 항목이 각 PR 내용과 일치하는지 확인
- [ ] README 옵션 테이블에 `tint` 옵션이 올바르게 추가되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)