### PR TITLE
feat(api): add outputLevels, temperature, and flip options

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1208,5 +1208,127 @@ describe('applyTint', () => {
     expect(rgba[0]).toBe(255);
     expect(rgba[1]).toBe(0);
     expect(rgba[2]).toBe(0);
+  });
+});
+
+describe('applyOutputLevels', () => {
+  it('outputMin=0, outputMax=128 → max pixel value 128', () => {
+    const rgba = new Uint8ClampedArray([255, 128, 0, 255]);
+    applyOutputLevels(rgba, 1, 1, 0, 128);
+    expect(rgba[0]).toBe(128);
+    expect(rgba[1]).toBe(64);
+    expect(rgba[2]).toBe(0);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('outputMin=128, outputMax=255 → min pixel value 128', () => {
+    const rgba = new Uint8ClampedArray([0, 128, 255, 255]);
+    applyOutputLevels(rgba, 1, 1, 128, 255);
+    expect(rgba[0]).toBe(128);
+    expect(rgba[1]).toBe(192);
+    expect(rgba[2]).toBe(255);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('no-op when outputMin=0, outputMax=255', () => {
+    const rgba = new Uint8ClampedArray([100, 200, 50, 255]);
+    applyOutputLevels(rgba, 1, 1, 0, 255);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(200);
+    expect(rgba[2]).toBe(50);
+  });
+});
+
+describe('validateOutputLevels', () => {
+  it('clamps to 0-255 range', () => {
+    const result = validateOutputLevels(-10, 300);
+    expect(result.outputMin).toBe(0);
+    expect(result.outputMax).toBe(255);
+    expect(result.swapped).toBe(false);
+  });
+
+  it('swaps when min > max', () => {
+    const result = validateOutputLevels(200, 100);
+    expect(result.outputMin).toBe(100);
+    expect(result.outputMax).toBe(200);
+    expect(result.swapped).toBe(true);
+  });
+});
+
+describe('applyTemperature', () => {
+  it('no-op when temperature=0', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyTemperature(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('temperature=50 → R increases, B decreases', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyTemperature(rgba, 1, 1, 50);
+    expect(rgba[0]).toBeGreaterThan(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBeLessThan(200);
+  });
+
+  it('temperature=-50 → B increases, R decreases', () => {
+    const rgba = new Uint8ClampedArray([200, 150, 100, 255]);
+    applyTemperature(rgba, 1, 1, -50);
+    expect(rgba[0]).toBeLessThan(200);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBeGreaterThan(100);
+  });
+
+  it('clamps to 0-255', () => {
+    const rgba = new Uint8ClampedArray([250, 150, 5, 255]);
+    applyTemperature(rgba, 1, 1, 100);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[2]).toBe(0);
+  });
+});
+
+describe('applyFlip', () => {
+  it('horizontal flip swaps left-right', () => {
+    // 2x1 image: [R, G]
+    const rgba = new Uint8ClampedArray([
+      255, 0, 0, 255,   0, 255, 0, 255,
+    ]);
+    applyFlip(rgba, 2, 1, true, false);
+    expect(rgba[0]).toBe(0);    // was green
+    expect(rgba[1]).toBe(255);
+    expect(rgba[4]).toBe(255);  // was red
+    expect(rgba[5]).toBe(0);
+  });
+
+  it('vertical flip swaps top-bottom', () => {
+    // 1x2 image: [R, G]
+    const rgba = new Uint8ClampedArray([
+      255, 0, 0, 255,   0, 255, 0, 255,
+    ]);
+    applyFlip(rgba, 1, 2, false, true);
+    expect(rgba[0]).toBe(0);    // was green (bottom)
+    expect(rgba[1]).toBe(255);
+    expect(rgba[4]).toBe(255);  // was red (top)
+    expect(rgba[5]).toBe(0);
+  });
+
+  it('both horizontal and vertical', () => {
+    // 2x2: [A, B, C, D] → flip both → [D, C, B, A]
+    const rgba = new Uint8ClampedArray([
+      10, 0, 0, 255,  20, 0, 0, 255,
+      30, 0, 0, 255,  40, 0, 0, 255,
+    ]);
+    applyFlip(rgba, 2, 2, true, true);
+    expect(rgba[0]).toBe(40);
+    expect(rgba[4]).toBe(30);
+    expect(rgba[8]).toBe(20);
+    expect(rgba[12]).toBe(10);
+  });
+
+  it('no-op when both false', () => {
+    const rgba = new Uint8ClampedArray([100, 200, 50, 255]);
+    applyFlip(rgba, 1, 1, false, false);
+    expect(rgba[0]).toBe(100);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -816,6 +816,110 @@ export function applyTint(
 }
 
 /**
+ * Remaps pixel output levels: maps [0, 255] → [outputMin, outputMax] linearly.
+ * Alpha channel is not modified.
+ */
+export function applyOutputLevels(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  outputMin: number,
+  outputMax: number,
+): void {
+  if (outputMin === 0 && outputMax === 255) return;
+  const range = outputMax - outputMin;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = Math.round(Math.max(0, Math.min(255, outputMin + rgba[off] * range / 255)));
+    rgba[off + 1] = Math.round(Math.max(0, Math.min(255, outputMin + rgba[off + 1] * range / 255)));
+    rgba[off + 2] = Math.round(Math.max(0, Math.min(255, outputMin + rgba[off + 2] * range / 255)));
+  }
+}
+
+/**
+ * Validates and normalizes outputLevels input values.
+ * Clamps outputMin/outputMax to 0-255 range.
+ * If outputMin > outputMax, swaps them and returns swapped=true.
+ */
+export function validateOutputLevels(
+  outputMin: number,
+  outputMax: number,
+): { outputMin: number; outputMax: number; swapped: boolean } {
+  let min = Math.max(0, Math.min(255, Math.round(outputMin)));
+  let max = Math.max(0, Math.min(255, Math.round(outputMax)));
+  let swapped = false;
+  if (min > max) {
+    [min, max] = [max, min];
+    swapped = true;
+  }
+  return { outputMin: min, outputMax: max, swapped };
+}
+
+/**
+ * Adjusts color temperature of RGB channels.
+ * Positive values add warmth (increase R, decrease B), negative add coolness (increase B, decrease R).
+ * Range: -100 to +100. Alpha channel is not modified.
+ */
+export function applyTemperature(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  temperature: number,
+): void {
+  if (temperature === 0) return;
+  const t = Math.max(-100, Math.min(100, temperature));
+  const rShift = Math.round(t * 255 / 100);
+  const bShift = Math.round(-t * 255 / 100);
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    rgba[off]     = Math.max(0, Math.min(255, rgba[off] + rShift));
+    rgba[off + 2] = Math.max(0, Math.min(255, rgba[off + 2] + bShift));
+  }
+}
+
+/**
+ * Flips image horizontally (left-right) and/or vertically (top-bottom).
+ * Alpha channel is included in the flip.
+ */
+export function applyFlip(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  horizontal: boolean,
+  vertical: boolean,
+): void {
+  if (!horizontal && !vertical) return;
+  if (horizontal) {
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < Math.floor(width / 2); x++) {
+        const left = (y * width + x) * 4;
+        const right = (y * width + (width - 1 - x)) * 4;
+        for (let c = 0; c < 4; c++) {
+          const tmp = rgba[left + c];
+          rgba[left + c] = rgba[right + c];
+          rgba[right + c] = tmp;
+        }
+      }
+    }
+  }
+  if (vertical) {
+    for (let y = 0; y < Math.floor(height / 2); y++) {
+      for (let x = 0; x < width; x++) {
+        const top = (y * width + x) * 4;
+        const bottom = ((height - 1 - y) * width + x) * 4;
+        for (let c = 0; c < 4; c++) {
+          const tmp = rgba[top + c];
+          rgba[top + c] = rgba[bottom + c];
+          rgba[bottom + c] = tmp;
+        }
+      }
+    }
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -220,6 +220,12 @@ export interface JP2LayerOptions {
   noise?: number;
   /** 이미지 전체에 색조 오버레이 적용 [R, G, B, strength] (strength: 0~1, 기본값 0.5). 원본 색상과 지정 색상을 블렌딩 */
   tint?: [number, number, number, number?];
+  /** 픽셀 출력 레벨 범위 조정. 0~255를 outputMin~outputMax로 선형 재매핑 (기본값: {outputMin: 0, outputMax: 255}) */
+  outputLevels?: { outputMin?: number; outputMax?: number };
+  /** 색 온도 조정 (-100~+100, 기본값: 0). 양수=난색(주황빛), 음수=한색(파란빛) */
+  temperature?: number;
+  /** 이미지 반전. horizontal=좌우 반전, vertical=상하 반전 (기본값: 둘 다 false) */
+  flip?: { horizontal?: boolean; vertical?: boolean };
 }
 
 export interface JP2LayerResult {
@@ -385,6 +391,9 @@ export async function createJP2TileLayer(
   const levels = options?.levels;
   const noise = options?.noise;
   const tint = options?.tint;
+  const outputLevels = options?.outputLevels;
+  const temperature = options?.temperature;
+  const flip = options?.flip;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -514,6 +523,10 @@ export async function createJP2TileLayer(
             applyContrast(decoded.data, decoded.width, decoded.height, contrast);
           }
 
+          if (temperature != null && temperature !== 0) {
+            applyTemperature(decoded.data, decoded.width, decoded.height, temperature);
+          }
+
           if (saturation != null && saturation !== 1.0) {
             applySaturation(decoded.data, decoded.width, decoded.height, saturation);
           }
@@ -586,6 +599,14 @@ export async function createJP2TileLayer(
             applyLevels(decoded.data, decoded.width, decoded.height, validated.inputMin, validated.inputMax);
           }
 
+          if (outputLevels) {
+            const validated = validateOutputLevels(outputLevels.outputMin ?? 0, outputLevels.outputMax ?? 255);
+            if (validated.swapped) {
+              debugWarn(`outputLevels.outputMin > outputLevels.outputMax, swapping values`);
+            }
+            applyOutputLevels(decoded.data, decoded.width, decoded.height, validated.outputMin, validated.outputMax);
+          }
+
           if (noise != null && noise > 0) {
             applyNoise(decoded.data, decoded.width, decoded.height, Math.min(noise, 255));
           }
@@ -645,6 +666,10 @@ export async function createJP2TileLayer(
                 d[off + 3] = 255; // alpha
               }
             }
+          }
+
+          if (flip && (flip.horizontal || flip.vertical)) {
+            applyFlip(decoded.data, decoded.width, decoded.height, !!flip.horizontal, !!flip.vertical);
           }
 
           if (onTileLoad) {


### PR DESCRIPTION
## Summary
- **outputLevels** (#198): 픽셀 출력 레벨 범위 재매핑 (`applyOutputLevels`, `validateOutputLevels`)
- **temperature** (#199): 색 온도 조정 -100(한색)~+100(난색) (`applyTemperature`)
- **flip** (#200): 이미지 수평/수직 반전 (`applyFlip`)

closes #198, closes #199, closes #200

## Test plan
- [x] `applyOutputLevels`: outputMin=0/outputMax=128, outputMin=128/outputMax=255, no-op 테스트
- [x] `validateOutputLevels`: 클램프, 스왑 테스트
- [x] `applyTemperature`: no-op, 난색(+50), 한색(-50), 클램프 테스트
- [x] `applyFlip`: 수평, 수직, 양방향, no-op 테스트
- [x] 전체 411개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)