### PR TITLE
feat(api): add vibrance and curves options (#203, #204)

### DIFF
--- a/src/pixel-conversion.spec.ts
+++ b/src/pixel-conversion.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { applyVibrance, applyCurves, validateCurves } from './pixel-conversion';
+
+describe('applyVibrance', () => {
+  it('vibrance=0이면 변경 없음', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyVibrance(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('채도가 낮은 색상에 더 강하게 작용한다', () => {
+    // Gray-ish pixel (low saturation)
+    const lowSat = new Uint8ClampedArray([120, 125, 130, 255]);
+    const lowSatOrig = new Uint8ClampedArray(lowSat);
+    applyVibrance(lowSat, 1, 1, 0.5);
+
+    // Saturated pixel
+    const highSat = new Uint8ClampedArray([255, 50, 50, 255]);
+    const highSatOrig = new Uint8ClampedArray(highSat);
+    applyVibrance(highSat, 1, 1, 0.5);
+
+    // Low saturation pixel should change more relative to its range
+    const lowDelta = Math.abs(lowSat[0] - lowSatOrig[0]) + Math.abs(lowSat[1] - lowSatOrig[1]) + Math.abs(lowSat[2] - lowSatOrig[2]);
+    const highDelta = Math.abs(highSat[0] - highSatOrig[0]) + Math.abs(highSat[1] - highSatOrig[1]) + Math.abs(highSat[2] - highSatOrig[2]);
+    // Low sat pixel should have some change
+    expect(lowDelta).toBeGreaterThan(0);
+    // High sat pixel should also change but the relative effect is weaker
+    // (absolute change may be larger due to wider range, but saturation-relative effect is smaller)
+  });
+
+  it('음수 vibrance는 채도를 낮춘다', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    const gray = Math.round(0.2126 * 100 + 0.7152 * 150 + 0.0722 * 200);
+    applyVibrance(rgba, 1, 1, -1);
+    // Should move closer to gray
+    expect(Math.abs(rgba[0] - gray)).toBeLessThanOrEqual(Math.abs(100 - gray));
+  });
+
+  it('alpha 채널은 수정하지 않는다', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 128]);
+    applyVibrance(rgba, 1, 1, 0.5);
+    expect(rgba[3]).toBe(128);
+  });
+
+  it('회색 픽셀(saturation=0)에도 안전하게 동작', () => {
+    const rgba = new Uint8ClampedArray([128, 128, 128, 255]);
+    applyVibrance(rgba, 1, 1, 1);
+    // Gray pixel: sat=0, amount=vibrance*1=1, so effect is maximal
+    // but since r-gray=0, g-gray=0, b-gray=0, result stays the same
+    expect(rgba[0]).toBe(128);
+    expect(rgba[1]).toBe(128);
+    expect(rgba[2]).toBe(128);
+  });
+});
+
+describe('validateCurves', () => {
+  it('유효한 curves 객체 통과', () => {
+    const identity = Array.from({ length: 256 }, (_, i) => i);
+    expect(validateCurves({ all: identity })).toBe(true);
+    expect(validateCurves({ r: identity, g: identity, b: identity })).toBe(true);
+    expect(validateCurves({})).toBe(true);
+  });
+
+  it('잘못된 입력 거부', () => {
+    expect(validateCurves(null)).toBe(false);
+    expect(validateCurves([])).toBe(false);
+    expect(validateCurves({ all: [1, 2, 3] })).toBe(false);
+    const bad = Array.from({ length: 256 }, () => 300);
+    expect(validateCurves({ r: bad })).toBe(false);
+  });
+});
+
+describe('applyCurves', () => {
+  it('all 커브만 적용', () => {
+    const invert = Array.from({ length: 256 }, (_, i) => 255 - i);
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyCurves(rgba, 1, 1, { all: invert });
+    expect(rgba[0]).toBe(155);
+    expect(rgba[1]).toBe(105);
+    expect(rgba[2]).toBe(55);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('채널별 커브 적용', () => {
+    const double = Array.from({ length: 256 }, (_, i) => Math.min(255, i * 2));
+    const rgba = new Uint8ClampedArray([50, 100, 200, 255]);
+    applyCurves(rgba, 1, 1, { r: double });
+    expect(rgba[0]).toBe(100); // 50*2
+    expect(rgba[1]).toBe(100); // unchanged
+    expect(rgba[2]).toBe(200); // unchanged
+  });
+
+  it('all 후 채널별 커브 순서로 적용', () => {
+    const addTen = Array.from({ length: 256 }, (_, i) => Math.min(255, i + 10));
+    const addFive = Array.from({ length: 256 }, (_, i) => Math.min(255, i + 5));
+    const rgba = new Uint8ClampedArray([100, 100, 100, 255]);
+    applyCurves(rgba, 1, 1, { all: addTen, r: addFive });
+    expect(rgba[0]).toBe(115); // 100+10=110, then 110+5=115
+    expect(rgba[1]).toBe(110); // 100+10=110
+    expect(rgba[2]).toBe(110); // 100+10=110
+  });
+
+  it('커브가 모두 없으면 변경 없음', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyCurves(rgba, 1, 1, {});
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('alpha 채널은 수정하지 않는다', () => {
+    const invert = Array.from({ length: 256 }, (_, i) => 255 - i);
+    const rgba = new Uint8ClampedArray([100, 150, 200, 128]);
+    applyCurves(rgba, 1, 1, { all: invert });
+    expect(rgba[3]).toBe(128);
+  });
+});

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -920,6 +920,90 @@ export function applyFlip(
 }
 
 /**
+ * Applies vibrance adjustment — selectively boosts saturation of less-saturated colors.
+ * vibrance > 0: boost low-saturation colors, vibrance < 0: desaturate low-saturation colors.
+ * Range: -1 to 1. Already-saturated colors are affected less to prevent oversaturation.
+ * Alpha channel is not modified.
+ */
+export function applyVibrance(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  vibrance: number,
+): void {
+  if (vibrance === 0) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const r = rgba[off], g = rgba[off + 1], b = rgba[off + 2];
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    // Current saturation ratio (0 = gray, 1 = fully saturated)
+    const sat = max === 0 ? 0 : (max - min) / max;
+    // Scale factor: low saturation → stronger effect
+    const amount = vibrance * (1 - sat);
+    const gray = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    rgba[off]     = Math.round(Math.max(0, Math.min(255, gray + (1 + amount) * (r - gray))));
+    rgba[off + 1] = Math.round(Math.max(0, Math.min(255, gray + (1 + amount) * (g - gray))));
+    rgba[off + 2] = Math.round(Math.max(0, Math.min(255, gray + (1 + amount) * (b - gray))));
+  }
+}
+
+/**
+ * Validates curves option: each channel array must have exactly 256 entries with values 0~255.
+ * Returns true if valid.
+ */
+export function validateCurves(
+  curves: unknown,
+): curves is { r?: number[]; g?: number[]; b?: number[]; all?: number[] } {
+  if (typeof curves !== 'object' || curves === null || Array.isArray(curves)) return false;
+  const obj = curves as Record<string, unknown>;
+  for (const key of ['r', 'g', 'b', 'all']) {
+    const arr = obj[key];
+    if (arr === undefined) continue;
+    if (!Array.isArray(arr) || arr.length !== 256) return false;
+    for (let i = 0; i < 256; i++) {
+      if (typeof arr[i] !== 'number' || arr[i] < 0 || arr[i] > 255) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Applies tone curves to RGB channels using LUT (Look-Up Table) mapping.
+ * `all` curve is applied first (common to all channels), then per-channel curves.
+ * Each curve is a 256-element array mapping input value (index) to output value.
+ * Alpha channel is not modified.
+ */
+export function applyCurves(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  curves: { r?: number[]; g?: number[]; b?: number[]; all?: number[] },
+): void {
+  const { r: rCurve, g: gCurve, b: bCurve, all: allCurve } = curves;
+  if (!rCurve && !gCurve && !bCurve && !allCurve) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    let r = rgba[off], g = rgba[off + 1], b = rgba[off + 2];
+    // Apply common curve first
+    if (allCurve) {
+      r = allCurve[r];
+      g = allCurve[g];
+      b = allCurve[b];
+    }
+    // Apply per-channel curves
+    if (rCurve) r = rCurve[r];
+    if (gCurve) g = gCurve[g];
+    if (bCurve) b = bCurve[b];
+    rgba[off] = Math.max(0, Math.min(255, r));
+    rgba[off + 1] = Math.max(0, Math.min(255, g));
+    rgba[off + 2] = Math.max(0, Math.min(255, b));
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -226,6 +226,10 @@ export interface JP2LayerOptions {
   temperature?: number;
   /** 이미지 반전. horizontal=좌우 반전, vertical=상하 반전 (기본값: 둘 다 false) */
   flip?: { horizontal?: boolean; vertical?: boolean };
+  /** 채도 낮은 색상 선택적 채도 증폭 (기본값: 0, 범위: -1~1). 양수=저채도 색상 강조, 음수=저채도 색상 감소. saturation과 달리 과채도 방지 */
+  vibrance?: number;
+  /** 톤 커브 조정 — 채널별 입출력 매핑. 각 채널은 256개 요소 배열(index→출력값). all은 공통 커브(채널별보다 먼저 적용) */
+  curves?: { r?: number[]; g?: number[]; b?: number[]; all?: number[] };
 }
 
 export interface JP2LayerResult {
@@ -394,6 +398,10 @@ export async function createJP2TileLayer(
   const outputLevels = options?.outputLevels;
   const temperature = options?.temperature;
   const flip = options?.flip;
+  const vibrance = options?.vibrance;
+  const curvesOpt = options?.curves != null && validateCurves(options.curves)
+    ? options.curves
+    : undefined;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -531,6 +539,10 @@ export async function createJP2TileLayer(
             applySaturation(decoded.data, decoded.width, decoded.height, saturation);
           }
 
+          if (vibrance != null && vibrance !== 0) {
+            applyVibrance(decoded.data, decoded.width, decoded.height, vibrance);
+          }
+
           if (hue != null && hue !== 0) {
             applyHue(decoded.data, decoded.width, decoded.height, hue);
           }
@@ -597,6 +609,10 @@ export async function createJP2TileLayer(
               debugWarn(`levels.inputMin > levels.inputMax, swapping values`);
             }
             applyLevels(decoded.data, decoded.width, decoded.height, validated.inputMin, validated.inputMax);
+          }
+
+          if (curvesOpt) {
+            applyCurves(decoded.data, decoded.width, decoded.height, curvesOpt);
           }
 
           if (outputLevels) {


### PR DESCRIPTION
## Summary
- **vibrance** (`JP2LayerOptions.vibrance`): 채도가 낮은 색상에 선택적으로 채도를 증폭하는 옵션 추가 (범위: -1~1)
- **curves** (`JP2LayerOptions.curves`): 채널별 톤 커브(256-entry LUT) 적용 옵션 추가 (`all`, `r`, `g`, `b` 채널)
- `pixel-conversion.ts`에 `applyVibrance()`, `applyCurves()`, `validateCurves()` 구현
- `source.ts` 파이프라인에 vibrance(saturation 이후), curves(levels 이후) 통합
- 12개 단위 테스트 추가, 전체 423 테스트 통과

closes #203
closes #204

## Test plan
- [x] `npm test` — 423 tests passed
- [ ] E2E: vibrance 옵션으로 저채도 이미지 렌더링 확인
- [ ] E2E: curves 옵션으로 S-커브 대비 강조 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)