### PR TITLE
docs: update CHANGELOG and README for sprint 56 (vibrance, curves)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 56
+
+### Added
+- **`JP2LayerOptions.vibrance`**: 저채도 색상에 선택적 채도 증폭 옵션 추가 (closes #203, PR #205)
+  - 타입: `number` (-1 ~ 1), 기본값: `0` (변화 없음)
+  - 이미 채도가 높은 색상에는 적게, 채도가 낮은 색상에는 더 많이 적용하는 지능형 채도 조정
+  - `pixel-conversion.ts`의 `applyVibrance()`, `validateVibrance()` 함수로 처리
+  - 적용 순서: ...saturation → vibrance → hue...
+- **`JP2LayerOptions.curves`**: 채널별 톤 커브(256-entry LUT) 적용 옵션 추가 (closes #204, PR #205)
+  - 타입: `{ all?: number[]; r?: number[]; g?: number[]; b?: number[] }`, 기본값: `undefined`
+  - `all`: 모든 채널에 적용할 256 엔트리 LUT
+  - `r`, `g`, `b`: 각 채널에 개별 적용할 256 엔트리 LUT (채널 LUT가 all보다 우선)
+  - `pixel-conversion.ts`의 `applyCurves()`, `validateCurves()` 함수로 처리
+  - 적용 순서: ...levels → curves → colorMap...
+
+---
+
 ## [Unreleased] — Sprint 55
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `outputLevels` | `{ outputMin?: number; outputMax?: number }` | `{ outputMin: 0, outputMax: 255 }` | 픽셀 출력 레벨 범위 재매핑. `[0, 255]` → `[outputMin, outputMax]` 선형 재매핑 |
 | `temperature` | `number` | `0` | 색 온도 조정 (-100 ~ +100). 양수=난색(주황빛), 음수=한색(파란빛) |
 | `flip` | `{ horizontal?: boolean; vertical?: boolean }` | - | 이미지 반전. `horizontal`=좌우 반전, `vertical`=상하 반전 |
+| `vibrance` | `number` | `0` | 저채도 색상에 선택적 채도 증폭 (-1 ~ 1). 이미 채도가 높은 색상에는 적게 적용 |
+| `curves` | `{ all?: number[]; r?: number[]; g?: number[]; b?: number[] }` | `undefined` | 채널별 톤 커브(256-entry LUT) 적용. `all`은 모든 채널, `r`/`g`/`b`는 개별 채널 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 56 항목 추가: `vibrance` (PR #205), `curves` (PR #205)
- README 옵션 테이블에 `vibrance`, `curves` 옵션 추가

## 반영된 PR
- #205: vibrance, curves 옵션 추가

## Test plan
- [ ] CHANGELOG Sprint 56 항목이 각 옵션 내용과 일치하는지 확인
- [ ] README 옵션 테이블에 2개 옵션이 올바르게 추가되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)