### PR TITLE
feat(api): add duotone, dodge, and burn options (#207, #208, #209)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1330,5 +1330,86 @@ describe('applyFlip', () => {
     const rgba = new Uint8ClampedArray([100, 200, 50, 255]);
     applyFlip(rgba, 1, 1, false, false);
     expect(rgba[0]).toBe(100);
+  });
+});
+
+describe('applyDuotone', () => {
+  it('maps black pixel to shadows color', () => {
+    const rgba = new Uint8ClampedArray([0, 0, 0, 255]);
+    applyDuotone(rgba, 1, 1, [20, 10, 80], [255, 230, 150]);
+    expect(rgba[0]).toBe(20);
+    expect(rgba[1]).toBe(10);
+    expect(rgba[2]).toBe(80);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('maps white pixel to highlights color', () => {
+    const rgba = new Uint8ClampedArray([255, 255, 255, 255]);
+    applyDuotone(rgba, 1, 1, [20, 10, 80], [255, 230, 150]);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(230);
+    expect(rgba[2]).toBe(150);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('interpolates mid-gray between shadows and highlights', () => {
+    const rgba = new Uint8ClampedArray([128, 128, 128, 255]);
+    applyDuotone(rgba, 1, 1, [0, 0, 0], [255, 255, 255]);
+    // lum ≈ 128/255 ≈ 0.502
+    expect(rgba[0]).toBeGreaterThan(120);
+    expect(rgba[0]).toBeLessThan(135);
+  });
+});
+
+describe('applyDodge', () => {
+  it('no-op when dodge=0', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyDodge(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('brightens pixels proportionally to their brightness', () => {
+    const rgba = new Uint8ClampedArray([200, 50, 0, 255]);
+    applyDodge(rgba, 1, 1, 0.5);
+    // bright pixel (200) should increase more than dark pixel (50)
+    expect(rgba[0]).toBeGreaterThan(200);
+    expect(rgba[1]).toBeGreaterThan(50);
+    // dark pixel (0) stays 0
+    expect(rgba[2]).toBe(0);
+  });
+
+  it('clamps to 255', () => {
+    const rgba = new Uint8ClampedArray([255, 255, 255, 255]);
+    applyDodge(rgba, 1, 1, 1.0);
+    expect(rgba[0]).toBe(255);
+  });
+});
+
+describe('applyBurn', () => {
+  it('no-op when burn=0', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyBurn(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+  });
+
+  it('darkens dark pixels more than bright pixels', () => {
+    const rgba = new Uint8ClampedArray([50, 200, 255, 255]);
+    applyBurn(rgba, 1, 1, 0.5);
+    // dark pixel (50) should decrease relatively more
+    expect(rgba[0]).toBeLessThan(50);
+    // bright pixel stays closer to original
+    expect(rgba[1]).toBeLessThan(200);
+    // max bright (255) stays 255: 255 * (1 - 0.5 * 0) = 255
+    expect(rgba[2]).toBe(255);
+  });
+
+  it('preserves alpha', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 128]);
+    applyBurn(rgba, 1, 1, 0.5);
+    expect(rgba[3]).toBe(128);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1004,6 +1004,79 @@ export function applyCurves(
 }
 
 /**
+ * Applies duotone effect: maps pixel luminance to a two-color gradient.
+ * Shadows color is used for dark pixels, highlights color for bright pixels.
+ * Alpha channel is not modified.
+ */
+export function applyDuotone(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  shadows: [number, number, number],
+  highlights: [number, number, number],
+): void {
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const lum = (0.2126 * rgba[off] + 0.7152 * rgba[off + 1] + 0.0722 * rgba[off + 2]) / 255;
+    rgba[off]     = Math.round(shadows[0] + lum * (highlights[0] - shadows[0]));
+    rgba[off + 1] = Math.round(shadows[1] + lum * (highlights[1] - shadows[1]));
+    rgba[off + 2] = Math.round(shadows[2] + lum * (highlights[2] - shadows[2]));
+  }
+}
+
+/**
+ * Applies dodge effect: selectively brightens highlights.
+ * Formula: result = pixel / (1 - dodge * normalized), where normalized = pixel / 255.
+ * dodge=0: no change, dodge=1: maximum dodge.
+ * Alpha channel is not modified.
+ */
+export function applyDodge(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  dodge: number,
+): void {
+  if (dodge === 0) return;
+  const d = Math.max(0, Math.min(1, dodge));
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    for (let c = 0; c < 3; c++) {
+      const v = rgba[off + c];
+      const normalized = v / 255;
+      const divisor = 1 - d * normalized;
+      rgba[off + c] = Math.round(Math.max(0, Math.min(255, divisor <= 0 ? 255 : v / divisor)));
+    }
+  }
+}
+
+/**
+ * Applies burn effect: selectively darkens shadows.
+ * Formula: result = pixel * (1 - burn * (1 - normalized)), where normalized = pixel / 255.
+ * burn=0: no change, burn=1: maximum burn.
+ * Alpha channel is not modified.
+ */
+export function applyBurn(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  burn: number,
+): void {
+  if (burn === 0) return;
+  const b = Math.max(0, Math.min(1, burn));
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    for (let c = 0; c < 3; c++) {
+      const v = rgba[off + c];
+      const normalized = v / 255;
+      rgba[off + c] = Math.round(Math.max(0, Math.min(255, v * (1 - b * (1 - normalized)))));
+    }
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -230,6 +230,12 @@ export interface JP2LayerOptions {
   vibrance?: number;
   /** 톤 커브 조정 — 채널별 입출력 매핑. 각 채널은 256개 요소 배열(index→출력값). all은 공통 커브(채널별보다 먼저 적용) */
   curves?: { r?: number[]; g?: number[]; b?: number[]; all?: number[] };
+  /** 두 가지 색상 그라디언트 톤 매핑. 밝기 기반으로 shadows→highlights 선형 보간 */
+  duotone?: { shadows: [number, number, number]; highlights: [number, number, number] };
+  /** 하이라이트 밝기 증폭 — 닷지 효과 (0~1, 기본값: 0). 밝은 영역을 선택적으로 밝게 처리 */
+  dodge?: number;
+  /** 섀도우 어둡기 증폭 — 번 효과 (0~1, 기본값: 0). 어두운 영역을 선택적으로 어둡게 처리 */
+  burn?: number;
 }
 
 export interface JP2LayerResult {
@@ -402,6 +408,9 @@ export async function createJP2TileLayer(
   const curvesOpt = options?.curves != null && validateCurves(options.curves)
     ? options.curves
     : undefined;
+  const duotone = options?.duotone;
+  const dodge = options?.dodge;
+  const burn = options?.burn;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -527,6 +536,14 @@ export async function createJP2TileLayer(
             applyBrightness(decoded.data, decoded.width, decoded.height, brightness);
           }
 
+          if (dodge != null && dodge !== 0) {
+            applyDodge(decoded.data, decoded.width, decoded.height, dodge);
+          }
+
+          if (burn != null && burn !== 0) {
+            applyBurn(decoded.data, decoded.width, decoded.height, burn);
+          }
+
           if (contrast != null && contrast !== 1.0) {
             applyContrast(decoded.data, decoded.width, decoded.height, contrast);
           }
@@ -629,6 +646,10 @@ export async function createJP2TileLayer(
 
           if (tint) {
             applyTint(decoded.data, decoded.width, decoded.height, tint[0], tint[1], tint[2], tint[3]);
+          }
+
+          if (duotone) {
+            applyDuotone(decoded.data, decoded.width, decoded.height, duotone.shadows, duotone.highlights);
           }
 
           if (colorMapLUT && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- **duotone**: 두 가지 색상(shadows/highlights) 그라디언트 톤 매핑 옵션 추가
- **dodge**: 하이라이트 밝기 증폭 효과 (0~1 범위)
- **burn**: 섀도우 어둡기 증폭 효과 (0~1 범위)

closes #207, closes #208, closes #209

## Test plan
- [x] `applyDuotone` 단위 테스트 (black→shadows, white→highlights, mid-gray 보간)
- [x] `applyDodge` 단위 테스트 (no-op, 밝기 비례 증폭, clamp)
- [x] `applyBurn` 단위 테스트 (no-op, 어둠도 비례 감소, alpha 보존)
- [x] 기존 432개 테스트 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)