### PR TITLE
docs: update CHANGELOG and README for sprint 57 (duotone, dodge, burn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 57
+
+### Added
+- **`JP2LayerOptions.duotone`**: 두 가지 색상(shadows/highlights) 그라디언트 톤 매핑 옵션 추가 (closes #207, PR #210)
+  - 타입: `{ shadows: [number, number, number]; highlights: [number, number, number] }`, 기본값: `undefined`
+  - 픽셀 휘도(luminance)를 기반으로 어두운 픽셀은 shadows 색상, 밝은 픽셀은 highlights 색상으로 매핑
+  - `pixel-conversion.ts`의 `applyDuotone()` 함수로 처리
+  - 적용 순서: curves 이후 최종 단계에 적용
+- **`JP2LayerOptions.dodge`**: 하이라이트 밝기 증폭(닷지) 효과 옵션 추가 (closes #208, PR #210)
+  - 타입: `number` (0 ~ 1), 기본값: `0` (변화 없음)
+  - 밝은 픽셀일수록 더 많이 밝아지는 비선형 닷지 효과
+  - `pixel-conversion.ts`의 `applyDodge()` 함수로 처리
+  - 적용 순서: curves 이후, burn 이전
+- **`JP2LayerOptions.burn`**: 섀도우 어둡기 증폭(번) 효과 옵션 추가 (closes #209, PR #210)
+  - 타입: `number` (0 ~ 1), 기본값: `0` (변화 없음)
+  - 어두운 픽셀일수록 더 많이 어두워지는 비선형 번 효과
+  - `pixel-conversion.ts`의 `applyBurn()` 함수로 처리
+  - 적용 순서: dodge 이후
+
+---
+
 ## [Unreleased] — Sprint 56
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `flip` | `{ horizontal?: boolean; vertical?: boolean }` | - | 이미지 반전. `horizontal`=좌우 반전, `vertical`=상하 반전 |
 | `vibrance` | `number` | `0` | 저채도 색상에 선택적 채도 증폭 (-1 ~ 1). 이미 채도가 높은 색상에는 적게 적용 |
 | `curves` | `{ all?: number[]; r?: number[]; g?: number[]; b?: number[] }` | `undefined` | 채널별 톤 커브(256-entry LUT) 적용. `all`은 모든 채널, `r`/`g`/`b`는 개별 채널 |
+| `duotone` | `{ shadows: [r,g,b]; highlights: [r,g,b] }` | `undefined` | 두 가지 색상(shadows/highlights) 그라디언트 톤 매핑. 픽셀 휘도에 따라 두 색상 사이를 선형 보간 |
+| `dodge` | `number` | `0` | 하이라이트 밝기 증폭(닷지) 효과 (0 ~ 1). 밝은 픽셀일수록 더 많이 밝아짐 |
+| `burn` | `number` | `0` | 섀도우 어둡기 증폭(번) 효과 (0 ~ 1). 어두운 픽셀일수록 더 많이 어두워짐 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 57 항목 추가: `duotone` (#207), `dodge` (#208), `burn` (#209)
- README 옵션 테이블에 `duotone`, `dodge`, `burn` 옵션 추가

## 반영된 PR
- #210: duotone, dodge, burn 옵션 추가

## Test plan
- [ ] CHANGELOG Sprint 57 항목이 각 옵션 내용과 일치하는지 확인
- [ ] README 옵션 테이블에 3개 옵션이 올바르게 추가되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)