### PR TITLE
feat(api): add solarize, shadowsHighlights, and clarity options (#212, #213, #214)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1411,5 +1411,86 @@ describe('applyBurn', () => {
     const rgba = new Uint8ClampedArray([100, 100, 100, 128]);
     applyBurn(rgba, 1, 1, 0.5);
     expect(rgba[3]).toBe(128);
+  });
+});
+
+describe('applySolarize', () => {
+  it('inverts channels above threshold', () => {
+    const rgba = new Uint8ClampedArray([200, 100, 50, 255]);
+    applySolarize(rgba, 1, 1, 128);
+    expect(rgba[0]).toBe(55);  // 200 >= 128 → 255-200=55
+    expect(rgba[1]).toBe(100); // 100 < 128 → unchanged
+    expect(rgba[2]).toBe(50);  // 50 < 128 → unchanged
+  });
+
+  it('preserves alpha', () => {
+    const rgba = new Uint8ClampedArray([200, 200, 200, 128]);
+    applySolarize(rgba, 1, 1, 128);
+    expect(rgba[3]).toBe(128);
+  });
+
+  it('threshold=0 inverts all channels', () => {
+    const rgba = new Uint8ClampedArray([100, 50, 0, 255]);
+    applySolarize(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(155);
+    expect(rgba[1]).toBe(205);
+    expect(rgba[2]).toBe(255);
+  });
+});
+
+describe('applyShadowsHighlights', () => {
+  it('brightens shadows with positive shadows value', () => {
+    const rgba = new Uint8ClampedArray([30, 30, 30, 255]);
+    applyShadowsHighlights(rgba, 1, 1, 50, 0);
+    expect(rgba[0]).toBeGreaterThan(30);
+    expect(rgba[1]).toBeGreaterThan(30);
+    expect(rgba[2]).toBeGreaterThan(30);
+  });
+
+  it('darkens highlights with negative highlights value', () => {
+    const rgba = new Uint8ClampedArray([220, 220, 220, 255]);
+    applyShadowsHighlights(rgba, 1, 1, 0, -50);
+    expect(rgba[0]).toBeLessThan(220);
+  });
+
+  it('no change when both are 0', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 255]);
+    applyShadowsHighlights(rgba, 1, 1, 0, 0);
+    expect(rgba[0]).toBe(100);
+  });
+
+  it('preserves alpha', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 128]);
+    applyShadowsHighlights(rgba, 1, 1, 50, -50);
+    expect(rgba[3]).toBe(128);
+  });
+});
+
+describe('applyClarity', () => {
+  it('no change when clarity=0', () => {
+    const rgba = new Uint8ClampedArray([100, 100, 100, 255]);
+    applyClarity(rgba, 1, 1, 0);
+    expect(rgba[0]).toBe(100);
+  });
+
+  it('enhances midtone contrast on larger image', () => {
+    // 3x3 image with uniform midtone center, darker surroundings
+    const rgba = new Uint8ClampedArray(3 * 3 * 4);
+    for (let i = 0; i < 9; i++) {
+      const off = i * 4;
+      rgba[off] = rgba[off + 1] = rgba[off + 2] = 80;
+      rgba[off + 3] = 255;
+    }
+    // Center pixel brighter
+    rgba[4 * 4] = rgba[4 * 4 + 1] = rgba[4 * 4 + 2] = 140;
+    applyClarity(rgba, 3, 3, 100);
+    // Center pixel should be pushed further from its blurred value (enhanced)
+    expect(rgba[4 * 4]).toBeGreaterThanOrEqual(140);
+  });
+
+  it('preserves alpha', () => {
+    const rgba = new Uint8ClampedArray([128, 128, 128, 100]);
+    applyClarity(rgba, 1, 1, 50);
+    expect(rgba[3]).toBe(100);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1077,6 +1077,110 @@ export function applyBurn(
 }
 
 /**
+ * Applies solarization effect: inverts pixels with channel values above the threshold.
+ * For each RGB channel, if value >= threshold, output = 255 - value; otherwise unchanged.
+ * Alpha channel is not modified.
+ */
+export function applySolarize(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  threshold: number,
+): void {
+  const t = Math.max(0, Math.min(255, Math.round(threshold)));
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    if (rgba[off] >= t) rgba[off] = 255 - rgba[off];
+    if (rgba[off + 1] >= t) rgba[off + 1] = 255 - rgba[off + 1];
+    if (rgba[off + 2] >= t) rgba[off + 2] = 255 - rgba[off + 2];
+  }
+}
+
+/**
+ * Adjusts shadows and highlights independently based on pixel luminance.
+ * shadows: -100~100, positive brightens dark areas, negative darkens them.
+ * highlights: -100~100, negative darkens bright areas, positive brightens them.
+ * Alpha channel is not modified.
+ */
+export function applyShadowsHighlights(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  shadows: number,
+  highlights: number,
+): void {
+  if (shadows === 0 && highlights === 0) return;
+  const sAmount = Math.max(-100, Math.min(100, shadows)) / 100;
+  const hAmount = Math.max(-100, Math.min(100, highlights)) / 100;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const lum = (0.2126 * rgba[off] + 0.7152 * rgba[off + 1] + 0.0722 * rgba[off + 2]) / 255;
+    // Shadow weight: strong for dark pixels, fades for bright
+    const shadowWeight = 1 - lum;
+    // Highlight weight: strong for bright pixels, fades for dark
+    const highlightWeight = lum;
+    const adjustment = sAmount * shadowWeight + hAmount * highlightWeight;
+    const shift = adjustment * 255;
+    rgba[off]     = Math.round(Math.max(0, Math.min(255, rgba[off] + shift)));
+    rgba[off + 1] = Math.round(Math.max(0, Math.min(255, rgba[off + 1] + shift)));
+    rgba[off + 2] = Math.round(Math.max(0, Math.min(255, rgba[off + 2] + shift)));
+  }
+}
+
+/**
+ * Applies clarity (local contrast enhancement) to RGBA data.
+ * Uses unsharp mask on midtones: enhances detail in mid-brightness areas.
+ * clarity: 0~100 (0=no change). Alpha channel is not modified.
+ */
+export function applyClarity(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  clarity: number,
+): void {
+  if (clarity <= 0) return;
+  const amount = Math.min(100, clarity) / 100;
+  const pixelCount = width * height;
+  // Create blurred copy using 3x3 Gaussian kernel
+  const blurred = new Float32Array(pixelCount * 3);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let sumR = 0, sumG = 0, sumB = 0, wSum = 0;
+      for (let ky = -1; ky <= 1; ky++) {
+        for (let kx = -1; kx <= 1; kx++) {
+          const ny = y + ky, nx = x + kx;
+          if (ny < 0 || ny >= height || nx < 0 || nx >= width) continue;
+          const w = (kx === 0 && ky === 0) ? 4 : (kx === 0 || ky === 0) ? 2 : 1;
+          const off = (ny * width + nx) * 4;
+          sumR += rgba[off] * w;
+          sumG += rgba[off + 1] * w;
+          sumB += rgba[off + 2] * w;
+          wSum += w;
+        }
+      }
+      const idx = (y * width + x) * 3;
+      blurred[idx] = sumR / wSum;
+      blurred[idx + 1] = sumG / wSum;
+      blurred[idx + 2] = sumB / wSum;
+    }
+  }
+  // Apply unsharp mask weighted by midtone strength
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const bIdx = i * 3;
+    const lum = (0.2126 * rgba[off] + 0.7152 * rgba[off + 1] + 0.0722 * rgba[off + 2]) / 255;
+    // Midtone weight: peaks at lum=0.5, fades at shadows/highlights
+    const midWeight = 4 * lum * (1 - lum);
+    const strength = amount * midWeight;
+    rgba[off]     = Math.round(Math.max(0, Math.min(255, rgba[off]     + strength * (rgba[off]     - blurred[bIdx]))));
+    rgba[off + 1] = Math.round(Math.max(0, Math.min(255, rgba[off + 1] + strength * (rgba[off + 1] - blurred[bIdx + 1]))));
+    rgba[off + 2] = Math.round(Math.max(0, Math.min(255, rgba[off + 2] + strength * (rgba[off + 2] - blurred[bIdx + 2]))));
+  }
+}
+
+/**
  * Computes min/max values from a decoded 16-bit buffer.
  */
 export function computeMinMax(

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -236,6 +236,12 @@ export interface JP2LayerOptions {
   dodge?: number;
   /** 섀도우 어둡기 증폭 — 번 효과 (0~1, 기본값: 0). 어두운 영역을 선택적으로 어둡게 처리 */
   burn?: number;
+  /** 솔라리제이션 효과 임계값 (0~255, 기본값: 128). 임계값 이상의 채널 값을 반전 */
+  solarize?: number;
+  /** 섀도우/하이라이트 독립 조정. shadows: -100~100, highlights: -100~100 (기본값: 0) */
+  shadowsHighlights?: { shadows?: number; highlights?: number };
+  /** 로컬 콘트라스트 강화 — clarity 효과 (0~100, 기본값: 0). 중간 톤 영역의 디테일 강조 */
+  clarity?: number;
 }
 
 export interface JP2LayerResult {
@@ -411,6 +417,9 @@ export async function createJP2TileLayer(
   const duotone = options?.duotone;
   const dodge = options?.dodge;
   const burn = options?.burn;
+  const solarize = options?.solarize;
+  const shadowsHighlights = options?.shadowsHighlights;
+  const clarity = options?.clarity;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -544,8 +553,20 @@ export async function createJP2TileLayer(
             applyBurn(decoded.data, decoded.width, decoded.height, burn);
           }
 
+          if (solarize != null) {
+            applySolarize(decoded.data, decoded.width, decoded.height, solarize);
+          }
+
+          if (shadowsHighlights) {
+            applyShadowsHighlights(decoded.data, decoded.width, decoded.height, shadowsHighlights.shadows ?? 0, shadowsHighlights.highlights ?? 0);
+          }
+
           if (contrast != null && contrast !== 1.0) {
             applyContrast(decoded.data, decoded.width, decoded.height, contrast);
+          }
+
+          if (clarity != null && clarity > 0) {
+            applyClarity(decoded.data, decoded.width, decoded.height, clarity);
           }
 
           if (temperature != null && temperature !== 0) {


### PR DESCRIPTION
## Summary
- **solarize** (#212): 임계값 이상의 채널 값을 반전시키는 솔라리제이션 효과
- **shadowsHighlights** (#213): 섀도우/하이라이트 영역을 독립적으로 밝기 조정
- **clarity** (#214): 중간 톤 영역의 로컬 콘트라스트를 강화하는 clarity 효과

closes #212, closes #213, closes #214

## Test plan
- [x] `applySolarize` 단위 테스트 (임계값 이상 반전, alpha 보존)
- [x] `applyShadowsHighlights` 단위 테스트 (섀도우 밝게, 하이라이트 어둡게, alpha 보존)
- [x] `applyClarity` 단위 테스트 (no-op at 0, 중간톤 강화, alpha 보존)
- [x] 전체 442개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)