### PR TITLE
docs: update CHANGELOG and README for sprint 58 (solarize, shadowsHighlights, clarity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 58
+
+### Added
+- **`JP2LayerOptions.solarize`**: 솔라리제이션 효과 임계값 옵션 추가 (closes #212, PR #215)
+  - 타입: `number` (0~255), 기본값: `128`
+  - 임계값 이상의 채널 값을 반전시켜 솔라리제이션 예술 효과 적용
+  - `pixel-conversion.ts`의 `applySolarize()` 함수로 처리
+  - 적용 순서: burn 이후
+- **`JP2LayerOptions.shadowsHighlights`**: 섀도우/하이라이트 독립 밝기 조정 옵션 추가 (closes #213, PR #215)
+  - 타입: `{ shadows?: number; highlights?: number }` (각 -100~100), 기본값: `{ shadows: 0, highlights: 0 }`
+  - shadows: 어두운 영역 밝기 조정 (양수=밝게, 음수=어둡게)
+  - highlights: 밝은 영역 밝기 조정 (양수=밝게, 음수=어둡게)
+  - `pixel-conversion.ts`의 `applyShadowsHighlights()` 함수로 처리
+  - 적용 순서: solarize 이후
+- **`JP2LayerOptions.clarity`**: 로컬 콘트라스트 강화(clarity) 효과 옵션 추가 (closes #214, PR #215)
+  - 타입: `number` (0~100), 기본값: `0` (변화 없음)
+  - 중간 톤 영역의 로컬 콘트라스트를 강화하여 디테일 선명도 향상
+  - `pixel-conversion.ts`의 `applyClarity()` 함수로 처리
+  - 적용 순서: shadowsHighlights 이후
+
+---
+
 ## [Unreleased] — Sprint 57
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `duotone` | `{ shadows: [r,g,b]; highlights: [r,g,b] }` | `undefined` | 두 가지 색상(shadows/highlights) 그라디언트 톤 매핑. 픽셀 휘도에 따라 두 색상 사이를 선형 보간 |
 | `dodge` | `number` | `0` | 하이라이트 밝기 증폭(닷지) 효과 (0 ~ 1). 밝은 픽셀일수록 더 많이 밝아짐 |
 | `burn` | `number` | `0` | 섀도우 어둡기 증폭(번) 효과 (0 ~ 1). 어두운 픽셀일수록 더 많이 어두워짐 |
+| `solarize` | `number` | `128` | 솔라리제이션 효과 임계값 (0~255). 임계값 이상의 채널 값을 반전 |
+| `shadowsHighlights` | `{ shadows?: number; highlights?: number }` | `{ shadows: 0, highlights: 0 }` | 섀도우/하이라이트 독립 밝기 조정 (각 -100~100). shadows=어두운 영역, highlights=밝은 영역 |
+| `clarity` | `number` | `0` | 로컬 콘트라스트 강화(clarity) 효과 강도 (0~100). 중간 톤 영역의 디테일 선명도 향상 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 58 항목 추가: `solarize` (#212), `shadowsHighlights` (#213), `clarity` (#214)
- README 옵션 테이블에 3개 옵션 추가

## 반영된 PR
- #215: solarize, shadowsHighlights, clarity 옵션 추가

## Test plan
- [ ] CHANGELOG Sprint 58 항목이 각 옵션 내용과 일치하는지 확인
- [ ] README 옵션 테이블에 3개 옵션이 올바르게 추가되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)