### PR TITLE
docs: update CHANGELOG and README for sprint 59 (crossProcess, grainFilm, halftone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 59
+
+### Added
+- **`JP2LayerOptions.crossProcess`**: 크로스 프로세싱 필름 효과 옵션 추가 (closes #217, PR #220)
+  - 타입: `number` (0 ~ 1), 기본값: `0` (변화 없음)
+  - 슬라이드 필름을 네거티브 현상액으로 처리한 것처럼 채널별 S커브(R)/리프트(G)/크러시(B) 적용
+  - `pixel-conversion.ts`의 `applyCrossProcess()` 함수로 처리
+  - 적용 순서: solarize 이후 grainFilm 이전
+- **`JP2LayerOptions.grainFilm`**: 필름 그레인 텍스처 효과 옵션 추가 (closes #218, PR #220)
+  - 타입: `number` (0 ~ 1), 기본값: `0` (변화 없음)
+  - 어두운 영역에 더 강한 그레인 노이즈를 추가하여 실제 필름 질감 시뮬레이션
+  - `pixel-conversion.ts`의 `applyGrainFilm()` 함수로 처리
+  - 적용 순서: crossProcess 이후 halftone 이전
+- **`JP2LayerOptions.halftone`**: 하프톤 점 패턴 효과 옵션 추가 (closes #219, PR #220)
+  - 타입: `number` (도트 크기, 픽셀 단위), 기본값: `0` (변화 없음, 2 미만이면 적용 안 됨)
+  - 이미지를 dotSize×dotSize 셀로 분할, 셀 평균 휘도에 따라 원형 도트 크기 조절
+  - 도트 외부 픽셀은 흰색으로 처리하여 인쇄물 하프톤 효과 재현
+  - `pixel-conversion.ts`의 `applyHalftone()` 함수로 처리
+  - 적용 순서: grainFilm 이후 (마지막 단계)
+
+---
+
 ## [Unreleased] — Sprint 58
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `solarize` | `number` | `128` | 솔라리제이션 효과 임계값 (0~255). 임계값 이상의 채널 값을 반전 |
 | `shadowsHighlights` | `{ shadows?: number; highlights?: number }` | `{ shadows: 0, highlights: 0 }` | 섀도우/하이라이트 독립 밝기 조정 (각 -100~100). shadows=어두운 영역, highlights=밝은 영역 |
 | `clarity` | `number` | `0` | 로컬 콘트라스트 강화(clarity) 효과 강도 (0~100). 중간 톤 영역의 디테일 선명도 향상 |
+| `crossProcess` | `number` | `0` | 크로스 프로세싱 효과 (0 ~ 1). 슬라이드 필름을 네거티브 현상액으로 처리한 것처럼 채널별 S커브/리프트/크러시 적용 |
+| `grainFilm` | `number` | `0` | 필름 그레인 텍스처 효과 (0 ~ 1). 어두운 영역에 더 강한 그레인 노이즈 추가로 실제 필름 질감 시뮬레이션 |
+| `halftone` | `number` | `0` | 하프톤 점 패턴 효과 (도트 크기, 픽셀 단위). 셀 평균 휘도에 따라 원형 도트 크기 조절, 2 미만이면 변화 없음 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 59 항목 추가: `crossProcess` (#217), `grainFilm` (#218), `halftone` (#219)
- README 옵션 테이블에 3개 옵션 추가

## 반영된 PR
- #220: crossProcess, grainFilm, halftone 옵션 추가 (미머지, 이슈 수정 중)

## Test plan
- [ ] CHANGELOG Sprint 59 항목이 각 옵션 내용과 일치하는지 확인
- [ ] README 옵션 테이블에 3개 옵션이 올바르게 추가되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)