### PR TITLE
docs: update CHANGELOG and README for sprint 61 (histogramEqualize, colorGrade) (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 61
+
+### Added
+- **`JP2LayerOptions.histogramEqualize`**: 히스토그램 평활화 옵션 추가 (closes #225, PR #227)
+  - 타입: `boolean`, 기본값: `false`
+  - 각 RGB 채널별 히스토그램 평활화로 저대비 원격탐사 JP2 이미지의 가시성 향상
+  - `pixel-conversion.ts`의 `applyHistogramEqualize()` 함수로 처리
+  - 적용 순서: halftone 이후
+- **`JP2LayerOptions.colorGrade`**: 스플릿 토닝(컬러 그레이딩) 옵션 추가 (closes #226, PR #227)
+  - 타입: `{ shadows?: [number, number, number]; highlights?: [number, number, number]; balance?: number; strength?: number }`, 기본값: `undefined`
+  - 섀도우/하이라이트 영역에 독립적 색조를 적용하는 스플릿 토닝 효과
+  - balance: 섀도우-하이라이트 균형 (-1~1), strength: 효과 강도 (0~1)
+  - `pixel-conversion.ts`의 `applyColorGrade()` 함수로 처리
+  - 적용 순서: histogramEqualize 이후 (마지막 단계)
+
+---
+
 ## [Unreleased] — Sprint 60
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `crossProcess` | `number` | `0` | 크로스 프로세싱 효과 (0 ~ 1). 슬라이드 필름을 네거티브 현상액으로 처리한 것처럼 채널별 S커브/리프트/크러시 적용 |
 | `grainFilm` | `number` | `0` | 필름 그레인 텍스처 효과 (0 ~ 1). 어두운 영역에 더 강한 그레인 노이즈 추가로 실제 필름 질감 시뮬레이션 |
 | `halftone` | `number` | `0` | 하프톤 점 패턴 효과 (도트 크기, 픽셀 단위). 셀 평균 휘도에 따라 원형 도트 크기 조절, 2 미만이면 변화 없음 |
+| `histogramEqualize` | `boolean` | `false` | 각 RGB 채널별 히스토그램 평활화. 저대비 원격탐사 JP2 이미지의 가시성 향상 |
+| `colorGrade` | `{ shadows?: [number, number, number]; highlights?: [number, number, number]; balance?: number; strength?: number }` | `undefined` | 섀도우/하이라이트 영역에 독립적 색조를 적용하는 스플릿 토닝 효과 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 61 섹션 추가: `histogramEqualize`, `colorGrade` 옵션 문서화
- README API 옵션 테이블에 `histogramEqualize`, `colorGrade` 행 추가

## 관련 PR
- 문서화 대상: PR #227 (closes #225, #226)

🤖 Generated with [Claude Code](https://claude.com/claude-code)