### PR TITLE
feat(api): add colorMatrix and autoContrast options (#229, #230)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1606,5 +1606,92 @@ describe('applyHalftone', () => {
     for (let i = 0; i < 16; i++) {
       expect(rgba[i * 4 + 3]).toBe(100);
     }
+  });
+});
+
+describe('applyColorMatrix', () => {
+  it('identity matrix leaves pixels unchanged', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    const identity = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ];
+    applyColorMatrix(rgba, 1, 1, identity);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(150);
+    expect(rgba[2]).toBe(200);
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('channel swap matrix swaps R and B', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    const swapRB = [
+      0, 0, 1, 0,
+      0, 1, 0, 0,
+      1, 0, 0, 0,
+      0, 0, 0, 1,
+    ];
+    applyColorMatrix(rgba, 1, 1, swapRB);
+    expect(rgba[0]).toBe(200); // was B
+    expect(rgba[1]).toBe(150); // G unchanged
+    expect(rgba[2]).toBe(100); // was R
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('clamps values to 0-255', () => {
+    const rgba = new Uint8ClampedArray([200, 200, 200, 255]);
+    const bright = [
+      2, 0, 0, 0,
+      0, 2, 0, 0,
+      0, 0, 2, 0,
+      0, 0, 0, 1,
+    ];
+    applyColorMatrix(rgba, 1, 1, bright);
+    expect(rgba[0]).toBe(255);
+    expect(rgba[1]).toBe(255);
+    expect(rgba[2]).toBe(255);
+  });
+
+  it('ignores invalid matrix length', () => {
+    const rgba = new Uint8ClampedArray([100, 150, 200, 255]);
+    applyColorMatrix(rgba, 1, 1, [1, 0, 0]);
+    expect(rgba[0]).toBe(100); // unchanged
+  });
+});
+
+describe('applyAutoContrast', () => {
+  it('stretches 50-200 range to 0-255', () => {
+    // 2x1 image: pixel1=[50,100,150,255], pixel2=[200,200,200,255]
+    const rgba = new Uint8ClampedArray([50, 100, 150, 255, 200, 200, 200, 255]);
+    applyAutoContrast(rgba, 2, 1);
+    // R: min=50, max=200, range=150 → 50→0, 200→255
+    expect(rgba[0]).toBe(0);
+    expect(rgba[4]).toBe(255);
+    // G: min=100, max=200, range=100 → 100→0, 200→255
+    expect(rgba[1]).toBe(0);
+    expect(rgba[5]).toBe(255);
+    // B: min=150, max=200, range=50 → 150→0, 200→255
+    expect(rgba[2]).toBe(0);
+    expect(rgba[6]).toBe(255);
+    // Alpha unchanged
+    expect(rgba[3]).toBe(255);
+    expect(rgba[7]).toBe(255);
+  });
+
+  it('single-color tile remains unchanged', () => {
+    const rgba = new Uint8ClampedArray([128, 128, 128, 255, 128, 128, 128, 255]);
+    applyAutoContrast(rgba, 2, 1);
+    expect(rgba[0]).toBe(128);
+    expect(rgba[1]).toBe(128);
+    expect(rgba[2]).toBe(128);
+  });
+
+  it('already full-range pixels stay the same', () => {
+    const rgba = new Uint8ClampedArray([0, 0, 0, 255, 255, 255, 255, 255]);
+    applyAutoContrast(rgba, 2, 1);
+    expect(rgba[0]).toBe(0);
+    expect(rgba[4]).toBe(255);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1404,3 +1404,63 @@ export function applyColorGrade(
     rgba[off + 2] = Math.max(0, Math.min(255, Math.round(b + blend * (tone[2] - b))));
   }
 }
+
+/**
+ * 4×4 선형 색상 변환 행렬을 적용한다.
+ * matrix는 row-major 순서의 16개 원소 배열 [R→R, R→G, R→B, R→A, G→R, ...].
+ * 각 픽셀의 [R,G,B,A]에 행렬을 곱한 후 0~255로 클램프한다.
+ */
+export function applyColorMatrix(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  matrix: number[],
+): void {
+  if (matrix.length !== 16) return;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const r = rgba[off];
+    const g = rgba[off + 1];
+    const b = rgba[off + 2];
+    const a = rgba[off + 3];
+    rgba[off]     = Math.max(0, Math.min(255, Math.round(matrix[0] * r + matrix[1] * g + matrix[2] * b + matrix[3] * a)));
+    rgba[off + 1] = Math.max(0, Math.min(255, Math.round(matrix[4] * r + matrix[5] * g + matrix[6] * b + matrix[7] * a)));
+    rgba[off + 2] = Math.max(0, Math.min(255, Math.round(matrix[8] * r + matrix[9] * g + matrix[10] * b + matrix[11] * a)));
+    rgba[off + 3] = Math.max(0, Math.min(255, Math.round(matrix[12] * r + matrix[13] * g + matrix[14] * b + matrix[15] * a)));
+  }
+}
+
+/**
+ * 타일별 자동 대비 스트레칭.
+ * 각 RGB 채널의 min/max를 구한 뒤 0~255로 선형 재매핑한다.
+ * 단색 타일(min === max)은 변경하지 않는다.
+ */
+export function applyAutoContrast(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+): void {
+  const pixelCount = width * height;
+  let rMin = 255, rMax = 0, gMin = 255, gMax = 0, bMin = 255, bMax = 0;
+
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const r = rgba[off], g = rgba[off + 1], b = rgba[off + 2];
+    if (r < rMin) rMin = r; if (r > rMax) rMax = r;
+    if (g < gMin) gMin = g; if (g > gMax) gMax = g;
+    if (b < bMin) bMin = b; if (b > bMax) bMax = b;
+  }
+
+  const rRange = rMax - rMin;
+  const gRange = gMax - gMin;
+  const bRange = bMax - bMin;
+  if (rRange === 0 && gRange === 0 && bRange === 0) return;
+
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    if (rRange > 0) rgba[off]     = Math.round((rgba[off] - rMin) / rRange * 255);
+    if (gRange > 0) rgba[off + 1] = Math.round((rgba[off + 1] - gMin) / gRange * 255);
+    if (bRange > 0) rgba[off + 2] = Math.round((rgba[off + 2] - bMin) / bRange * 255);
+  }
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -257,6 +257,10 @@ export interface JP2LayerOptions {
     balance?: number;
     strength?: number;
   };
+  /** 4×4 선형 색상 변환 행렬 (row-major 16개 원소). 각 픽셀의 [R,G,B,A]에 행렬 곱 적용 후 0~255 클램프 */
+  colorMatrix?: number[];
+  /** 타일별 자동 대비 스트레칭 (기본값: false). 각 RGB 채널의 min/max를 0~255로 선형 재매핑 */
+  autoContrast?: boolean;
 }
 
 export interface JP2LayerResult {
@@ -440,6 +444,10 @@ export async function createJP2TileLayer(
   const halftone = options?.halftone;
   const histogramEqualize = options?.histogramEqualize;
   const colorGrade = options?.colorGrade;
+  const colorMatrix = options?.colorMatrix != null && options.colorMatrix.length === 16
+    ? options.colorMatrix
+    : undefined;
+  const autoContrast = options?.autoContrast;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -597,6 +605,10 @@ export async function createJP2TileLayer(
             applyColorGrade(decoded.data, decoded.width, decoded.height, colorGrade);
           }
 
+          if (colorMatrix) {
+            applyColorMatrix(decoded.data, decoded.width, decoded.height, colorMatrix);
+          }
+
           if (temperature != null && temperature !== 0) {
             applyTemperature(decoded.data, decoded.width, decoded.height, temperature);
           }
@@ -718,6 +730,10 @@ export async function createJP2TileLayer(
 
           if (histogramEqualize) {
             applyHistogramEqualize(decoded.data, decoded.width, decoded.height);
+          }
+
+          if (autoContrast) {
+            applyAutoContrast(decoded.data, decoded.width, decoded.height);
           }
 
           if (colormap && info.componentCount === 1) {


### PR DESCRIPTION
## Summary
- **colorMatrix** (`number[]`): 4×4 선형 색상 변환 행렬을 픽셀에 적용 (채널 믹싱, 색공간 보정 등)
- **autoContrast** (`boolean`): 타일별 RGB 채널 min/max를 0~255로 선형 스트레칭

closes #229
closes #230

## Test plan
- [x] 항등 행렬 → 픽셀 불변 검증
- [x] 채널 스왑 행렬 검증
- [x] 0~255 클램프 검증
- [x] 잘못된 행렬 길이 무시 검증
- [x] 50~200 범위 → 0~255 스트레칭 검증
- [x] 단색 타일 불변 검증
- [x] 이미 full-range인 경우 불변 검증
- [x] `npm test` 466 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)