### PR TITLE
docs: update CHANGELOG and README for sprint 62 (colorMatrix, autoContrast) (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 62
+
+### Added
+- **`JP2LayerOptions.colorMatrix`**: 4×4 선형 색상 변환 행렬 옵션 추가 (closes #229, PR #231)
+  - 타입: `number[]` (row-major 16개 원소), 길이가 16이 아니면 무시
+  - 각 픽셀의 [R, G, B, A]에 행렬 곱을 적용한 뒤 0~255 클램프
+  - 채널 믹싱, 색공간 보정 등 다양한 선형 색상 변환에 활용
+  - `pixel-conversion.ts`의 `applyColorMatrix()` 함수로 처리
+  - 적용 순서: colorGrade 이후 temperature 이전
+- **`JP2LayerOptions.autoContrast`**: 타일별 자동 대비 스트레칭 옵션 추가 (closes #230, PR #231)
+  - 타입: `boolean`, 기본값: `false`
+  - 각 RGB 채널의 min/max를 0~255로 선형 재매핑하여 대비 자동 최적화
+  - 단색(min === max) 타일에는 적용하지 않아 안정적
+  - `pixel-conversion.ts`의 `applyAutoContrast()` 함수로 처리
+  - 적용 순서: histogramEqualize 이후 (colormap 이전)
+
+---
+
 ## [Unreleased] — Sprint 61
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `halftone` | `number` | `0` | 하프톤 점 패턴 효과 (도트 크기, 픽셀 단위). 셀 평균 휘도에 따라 원형 도트 크기 조절, 2 미만이면 변화 없음 |
 | `histogramEqualize` | `boolean` | `false` | 각 RGB 채널별 히스토그램 평활화. 저대비 원격탐사 JP2 이미지의 가시성 향상 |
 | `colorGrade` | `{ shadows?: [number, number, number]; highlights?: [number, number, number]; balance?: number; strength?: number }` | `undefined` | 섀도우/하이라이트 영역에 독립적 색조를 적용하는 스플릿 토닝 효과 |
+| `colorMatrix` | `number[]` | `undefined` | 4×4 선형 색상 변환 행렬 (row-major 16개 원소). 각 픽셀의 [R,G,B,A]에 행렬 곱 적용 후 0~255 클램프. 채널 믹싱·색공간 보정에 활용. 길이가 16이 아니면 무시 |
+| `autoContrast` | `boolean` | `false` | 타일별 자동 대비 스트레칭. 각 RGB 채널의 min/max를 0~255로 선형 재매핑하여 대비 자동 최적화 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 62 섹션 추가: `colorMatrix`, `autoContrast` 옵션 문서화
- README API 옵션 테이블에 `colorMatrix`, `autoContrast` 행 추가

## 관련 PR
- 문서화 대상: PR #231 (closes #229, #230)

🤖 Generated with [Claude Code](https://claude.com/claude-code)