### PR TITLE
feat(api): add chromaKey and median options (#233, #234)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1693,5 +1693,65 @@ describe('applyAutoContrast', () => {
     applyAutoContrast(rgba, 2, 1);
     expect(rgba[0]).toBe(0);
     expect(rgba[4]).toBe(255);
+  });
+});
+
+describe('applyChromaKey', () => {
+  it('exact match (tolerance=0) makes pixel transparent', () => {
+    const rgba = new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255]);
+    applyChromaKey(rgba, 2, 1, [255, 0, 0], 0);
+    expect(rgba[3]).toBe(0);   // red pixel → transparent
+    expect(rgba[7]).toBe(255); // green pixel → unchanged
+  });
+
+  it('tolerance>0 makes nearby colors transparent', () => {
+    // color [100,100,100], pixel [105,100,100] → distance = 5
+    const rgba = new Uint8ClampedArray([105, 100, 100, 255]);
+    applyChromaKey(rgba, 1, 1, [100, 100, 100], 5);
+    expect(rgba[3]).toBe(0); // within tolerance
+  });
+
+  it('pixel outside tolerance stays opaque', () => {
+    // color [100,100,100], pixel [110,100,100] → distance = 10
+    const rgba = new Uint8ClampedArray([110, 100, 100, 255]);
+    applyChromaKey(rgba, 1, 1, [100, 100, 100], 5);
+    expect(rgba[3]).toBe(255); // outside tolerance
+  });
+});
+
+describe('applyMedian', () => {
+  it('removes single salt pixel in 3x3 neighborhood', () => {
+    // 3x3 image: center pixel is salt (255,255,255), rest are (50,50,50)
+    const v = 50;
+    const rgba = new Uint8ClampedArray([
+      v,v,v,255, v,v,v,255, v,v,v,255,
+      v,v,v,255, 255,255,255,255, v,v,v,255,
+      v,v,v,255, v,v,v,255, v,v,v,255,
+    ]);
+    applyMedian(rgba, 3, 3, 1);
+    // center pixel should become 50 (median of eight 50s and one 255)
+    const center = 4 * 4; // pixel index 4
+    expect(rgba[center]).toBe(v);
+    expect(rgba[center + 1]).toBe(v);
+    expect(rgba[center + 2]).toBe(v);
+    expect(rgba[center + 3]).toBe(255); // alpha unchanged
+  });
+
+  it('preserves uniform pixels', () => {
+    const rgba = new Uint8ClampedArray([
+      100,100,100,255, 100,100,100,255,
+      100,100,100,255, 100,100,100,255,
+    ]);
+    applyMedian(rgba, 2, 2, 1);
+    expect(rgba[0]).toBe(100);
+    expect(rgba[1]).toBe(100);
+    expect(rgba[2]).toBe(100);
+  });
+
+  it('clamps radius to 1-5 range', () => {
+    const rgba = new Uint8ClampedArray([50,50,50,255, 200,200,200,255, 50,50,50,255, 200,200,200,255]);
+    // radius 10 should be clamped to 5, should not throw
+    applyMedian(rgba, 2, 2, 10);
+    expect(rgba[3]).toBe(255); // alpha preserved
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1464,3 +1464,88 @@ export function applyAutoContrast(
     if (bRange > 0) rgba[off + 2] = Math.round((rgba[off + 2] - bMin) / bRange * 255);
   }
 }
+
+/**
+ * 특정 RGB 색상과 유클리드 거리가 tolerance 이내인 픽셀의 알파를 0으로 설정한다 (크로마키 효과).
+ * @param rgba - RGBA 픽셀 데이터
+ * @param width - 이미지 너비
+ * @param height - 이미지 높이
+ * @param color - 투명 처리할 RGB 색상 [R, G, B]
+ * @param tolerance - 색상 허용 오차 (유클리드 거리, 기본값: 0)
+ */
+export function applyChromaKey(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  color: [number, number, number],
+  tolerance: number = 0,
+): void {
+  const [cr, cg, cb] = color;
+  const tolSq = tolerance * tolerance;
+  const pixelCount = width * height;
+  for (let i = 0; i < pixelCount; i++) {
+    const off = i * 4;
+    const dr = rgba[off] - cr;
+    const dg = rgba[off + 1] - cg;
+    const db = rgba[off + 2] - cb;
+    if (dr * dr + dg * dg + db * db <= tolSq) {
+      rgba[off + 3] = 0;
+    }
+  }
+}
+
+/**
+ * 중앙값 필터를 적용하여 salt-and-pepper 노이즈를 제거한다.
+ * 각 픽셀 주변 (2*radius+1)² 윈도우의 R/G/B 중앙값을 선택한다. 알파는 변경하지 않는다.
+ * @param rgba - RGBA 픽셀 데이터
+ * @param width - 이미지 너비
+ * @param height - 이미지 높이
+ * @param radius - 필터 반경 (1~5, 클램프 적용)
+ */
+export function applyMedian(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  radius: number,
+): void {
+  radius = Math.max(1, Math.min(5, Math.round(radius)));
+  const pixelCount = width * height;
+  const out = new Uint8ClampedArray(pixelCount * 4);
+  const size = 2 * radius + 1;
+  const maxSamples = size * size;
+
+  const rBuf = new Uint8Array(maxSamples);
+  const gBuf = new Uint8Array(maxSamples);
+  const bBuf = new Uint8Array(maxSamples);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let count = 0;
+      for (let dy = -radius; dy <= radius; dy++) {
+        const ny = y + dy;
+        if (ny < 0 || ny >= height) continue;
+        for (let dx = -radius; dx <= radius; dx++) {
+          const nx = x + dx;
+          if (nx < 0 || nx >= width) continue;
+          const off = (ny * width + nx) * 4;
+          rBuf[count] = rgba[off];
+          gBuf[count] = rgba[off + 1];
+          bBuf[count] = rgba[off + 2];
+          count++;
+        }
+      }
+      const rSorted = rBuf.subarray(0, count).sort();
+      const gSorted = gBuf.subarray(0, count).sort();
+      const bSorted = bBuf.subarray(0, count).sort();
+      const mid = count >> 1;
+
+      const outOff = (y * width + x) * 4;
+      out[outOff] = rSorted[mid];
+      out[outOff + 1] = gSorted[mid];
+      out[outOff + 2] = bSorted[mid];
+      out[outOff + 3] = rgba[(y * width + x) * 4 + 3];
+    }
+  }
+
+  rgba.set(out);
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -261,6 +261,13 @@ export interface JP2LayerOptions {
   colorMatrix?: number[];
   /** 타일별 자동 대비 스트레칭 (기본값: false). 각 RGB 채널의 min/max를 0~255로 선형 재매핑 */
   autoContrast?: boolean;
+  /** 특정 RGB 색상을 투명 처리 (크로마키 효과). color: [R,G,B], tolerance: 유클리드 거리 허용 오차 (기본값: 0) */
+  chromaKey?: {
+    color: [number, number, number];
+    tolerance?: number;
+  };
+  /** 중앙값 필터 반경 (1~5). salt-and-pepper 노이즈 제거에 효과적, 엣지 보존 */
+  median?: number;
 }
 
 export interface JP2LayerResult {
@@ -448,6 +455,8 @@ export async function createJP2TileLayer(
     ? options.colorMatrix
     : undefined;
   const autoContrast = options?.autoContrast;
+  const chromaKey = options?.chromaKey;
+  const median = options?.median;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -565,6 +574,10 @@ export async function createJP2TileLayer(
             applyNodata(decoded.data, decoded.width, decoded.height, info.componentCount, nodataValues, nodataTolerance);
           }
 
+          if (chromaKey) {
+            applyChromaKey(decoded.data, decoded.width, decoded.height, chromaKey.color, chromaKey.tolerance ?? 0);
+          }
+
           if (gamma != null && gamma !== 1.0) {
             applyGamma(decoded.data, decoded.width, decoded.height, gamma);
           }
@@ -643,6 +656,10 @@ export async function createJP2TileLayer(
 
           if (blur != null && blur > 0) {
             applyBlur(decoded.data, decoded.width, decoded.height, blur);
+          }
+
+          if (median != null && median >= 1) {
+            applyMedian(decoded.data, decoded.width, decoded.height, median);
           }
 
           if (sepia != null && sepia !== 0) {


### PR DESCRIPTION
## Summary
- **chromaKey** 옵션: 특정 RGB 색상과 유클리드 거리 기반으로 픽셀을 투명 처리 (크로마키 효과), closes #233
- **median** 옵션: 중앙값 필터로 salt-and-pepper 노이즈 제거, 엣지 보존, closes #234

## Changes
- `pixel-conversion.ts`: `applyChromaKey()`, `applyMedian()` 함수 추가
- `source.ts`: `JP2LayerOptions` 타입 정의 및 파이프라인 통합
- `pixel-conversion.test.ts`: 6개 단위 테스트 추가

## Test plan
- [x] `npm test` — 472 tests passed
- [ ] E2E: chromaKey로 배경색 투명 처리 확인
- [ ] E2E: median 필터로 노이즈 픽셀 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)