### PR TITLE
feat(api): chromaKey tolerance tests & median kernelSize option

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1717,10 +1717,35 @@ describe('applyChromaKey', () => {
     applyChromaKey(rgba, 1, 1, [100, 100, 100], 5);
     expect(rgba[3]).toBe(255); // outside tolerance
   });
+
+  it('tolerance at exact boundary makes pixel transparent', () => {
+    // color [0,0,0], pixel [3,4,0] → distance = sqrt(9+16) = 5
+    const rgba = new Uint8ClampedArray([3, 4, 0, 255]);
+    applyChromaKey(rgba, 1, 1, [0, 0, 0], 5);
+    expect(rgba[3]).toBe(0); // exactly at tolerance boundary
+  });
+
+  it('default tolerance=0 requires exact match', () => {
+    const rgba = new Uint8ClampedArray([0, 0, 1, 255]);
+    applyChromaKey(rgba, 1, 1, [0, 0, 0]);
+    expect(rgba[3]).toBe(255); // off by 1 → opaque
+  });
+
+  it('large tolerance makes all similar colors transparent', () => {
+    const rgba = new Uint8ClampedArray([
+      255, 0, 0, 255,
+      200, 50, 50, 255,
+      0, 255, 0, 255,
+    ]);
+    applyChromaKey(rgba, 3, 1, [255, 0, 0], 100);
+    expect(rgba[3]).toBe(0);   // exact match
+    expect(rgba[7]).toBe(0);   // within tolerance (dist ≈ 86.6)
+    expect(rgba[11]).toBe(255); // far away
+  });
 });
 
 describe('applyMedian', () => {
-  it('removes single salt pixel in 3x3 neighborhood', () => {
+  it('removes single salt pixel in 3x3 neighborhood (kernelSize=3)', () => {
     // 3x3 image: center pixel is salt (255,255,255), rest are (50,50,50)
     const v = 50;
     const rgba = new Uint8ClampedArray([
@@ -1728,7 +1753,7 @@ describe('applyMedian', () => {
       v,v,v,255, 255,255,255,255, v,v,v,255,
       v,v,v,255, v,v,v,255, v,v,v,255,
     ]);
-    applyMedian(rgba, 3, 3, 1);
+    applyMedian(rgba, 3, 3, 3);
     // center pixel should become 50 (median of eight 50s and one 255)
     const center = 4 * 4; // pixel index 4
     expect(rgba[center]).toBe(v);
@@ -1742,16 +1767,55 @@ describe('applyMedian', () => {
       100,100,100,255, 100,100,100,255,
       100,100,100,255, 100,100,100,255,
     ]);
-    applyMedian(rgba, 2, 2, 1);
+    applyMedian(rgba, 2, 2, 3);
     expect(rgba[0]).toBe(100);
     expect(rgba[1]).toBe(100);
     expect(rgba[2]).toBe(100);
   });
 
-  it('clamps radius to 1-5 range', () => {
+  it('clamps kernelSize to 3-11 range', () => {
     const rgba = new Uint8ClampedArray([50,50,50,255, 200,200,200,255, 50,50,50,255, 200,200,200,255]);
-    // radius 10 should be clamped to 5, should not throw
-    applyMedian(rgba, 2, 2, 10);
+    // kernelSize 99 should be clamped to 11, should not throw
+    applyMedian(rgba, 2, 2, 99);
     expect(rgba[3]).toBe(255); // alpha preserved
+  });
+
+  it('even kernelSize is rounded up to odd', () => {
+    const v = 50;
+    const rgba = new Uint8ClampedArray([
+      v,v,v,255, v,v,v,255, v,v,v,255,
+      v,v,v,255, 255,255,255,255, v,v,v,255,
+      v,v,v,255, v,v,v,255, v,v,v,255,
+    ]);
+    applyMedian(rgba, 3, 3, 4); // 4 → 5 (kernelSize=5, radius=2)
+    const center = 4 * 4;
+    expect(rgba[center]).toBe(v); // still median of mostly 50s
+  });
+
+  it('kernelSize=5 uses 5x5 window', () => {
+    // 5x5 image: center pixel is salt, rest are (30,30,30)
+    const v = 30;
+    const pixels = [];
+    for (let i = 0; i < 25; i++) {
+      if (i === 12) pixels.push(255, 255, 255, 255);
+      else pixels.push(v, v, v, 255);
+    }
+    const rgba = new Uint8ClampedArray(pixels);
+    applyMedian(rgba, 5, 5, 5);
+    const center = 12 * 4;
+    expect(rgba[center]).toBe(v);
+  });
+
+  it('edge pixels use only valid neighbors (skip boundary)', () => {
+    // 3x3 image, check corner pixel (0,0) which has only 4 neighbors with kernelSize=3
+    const rgba = new Uint8ClampedArray([
+      10,10,10,255, 20,20,20,255, 30,30,30,255,
+      40,40,40,255, 50,50,50,255, 60,60,60,255,
+      70,70,70,255, 80,80,80,255, 90,90,90,255,
+    ]);
+    applyMedian(rgba, 3, 3, 3);
+    // corner (0,0) neighbors: [10,20,40,50] → sorted [10,20,40,50] → median index 2 = 40
+    // (4 elements, mid = 4>>1 = 2, so value at index 2 = 40)
+    expect(rgba[0]).toBe(40);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1496,23 +1496,25 @@ export function applyChromaKey(
 
 /**
  * 중앙값 필터를 적용하여 salt-and-pepper 노이즈를 제거한다.
- * 각 픽셀 주변 (2*radius+1)² 윈도우의 R/G/B 중앙값을 선택한다. 알파는 변경하지 않는다.
+ * 각 픽셀 주변 kernelSize² 윈도우의 R/G/B 중앙값을 선택한다. 알파는 변경하지 않는다.
+ * 가장자리 처리: 경계 밖 픽셀은 건너뛰고(skip) 유효 이웃만으로 중앙값 계산 (클램프 아님).
  * @param rgba - RGBA 픽셀 데이터
  * @param width - 이미지 너비
  * @param height - 이미지 높이
- * @param radius - 필터 반경 (1~5, 클램프 적용)
+ * @param kernelSize - 커널 크기 (홀수, 3~11). 짝수면 +1 처리. 범위 밖이면 클램프.
  */
 export function applyMedian(
   rgba: Uint8ClampedArray,
   width: number,
   height: number,
-  radius: number,
+  kernelSize: number,
 ): void {
-  radius = Math.max(1, Math.min(5, Math.round(radius)));
+  kernelSize = Math.max(3, Math.min(11, Math.round(kernelSize)));
+  if (kernelSize % 2 === 0) kernelSize++;
+  const radius = (kernelSize - 1) / 2;
   const pixelCount = width * height;
   const out = new Uint8ClampedArray(pixelCount * 4);
-  const size = 2 * radius + 1;
-  const maxSamples = size * size;
+  const maxSamples = kernelSize * kernelSize;
 
   const rBuf = new Uint8Array(maxSamples);
   const gBuf = new Uint8Array(maxSamples);

--- a/src/source.ts
+++ b/src/source.ts
@@ -266,8 +266,13 @@ export interface JP2LayerOptions {
     color: [number, number, number];
     tolerance?: number;
   };
-  /** 중앙값 필터 반경 (1~5). salt-and-pepper 노이즈 제거에 효과적, 엣지 보존 */
-  median?: number;
+  /**
+   * 중앙값 필터. salt-and-pepper 노이즈 제거에 효과적, 엣지 보존.
+   * - number: 커널 크기 (홀수, 3~11). 예: 3 → 3×3 윈도우
+   * - object: { kernelSize: number } 형태로 지정 가능
+   * 가장자리 처리: 경계 밖 픽셀은 무시 (skip) 하여 유효 이웃만으로 중앙값 계산
+   */
+  median?: number | { kernelSize: number };
 }
 
 export interface JP2LayerResult {
@@ -456,7 +461,9 @@ export async function createJP2TileLayer(
     : undefined;
   const autoContrast = options?.autoContrast;
   const chromaKey = options?.chromaKey;
-  const median = options?.median;
+  const medianKernelSize = options?.median != null
+    ? (typeof options.median === 'number' ? options.median : options.median.kernelSize)
+    : undefined;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -658,8 +665,8 @@ export async function createJP2TileLayer(
             applyBlur(decoded.data, decoded.width, decoded.height, blur);
           }
 
-          if (median != null && median >= 1) {
-            applyMedian(decoded.data, decoded.width, decoded.height, median);
+          if (medianKernelSize != null && medianKernelSize >= 3) {
+            applyMedian(decoded.data, decoded.width, decoded.height, medianKernelSize);
           }
 
           if (sepia != null && sepia !== 0) {


### PR DESCRIPTION
## Summary
- **#236**: chromaKey tolerance 기능에 대한 추가 단위 테스트 (경계값, 기본값, 넓은 범위)
- **#237**: median 필터 파라미터를 radius → kernelSize(홀수, 3~11)로 변경, `number | { kernelSize }` 형태 지원, 가장자리 처리(skip boundary) 문서화

closes #236
closes #237

## Test plan
- [x] `npm test` 478 테스트 전체 통과
- [ ] chromaKey tolerance 경계값/기본값/넓은 범위 테스트 확인
- [ ] median kernelSize 3/5, 짝수→홀수 변환, 클램프, 가장자리 처리 테스트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)