### PR TITLE
feat(api): add unsharpMask and bloom options (#241, #242)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1817,5 +1817,94 @@ describe('applyMedian', () => {
     // corner (0,0) neighbors: [10,20,40,50] → sorted [10,20,40,50] → median index 2 = 40
     // (4 elements, mid = 4>>1 = 2, so value at index 2 = 40)
     expect(rgba[0]).toBe(40);
+  });
+});
+
+describe('applyUnsharpMask', () => {
+  it('sharpens edges by amplifying difference from blurred version', () => {
+    // 3x3 image: uniform 100 except center is 200
+    const v = 100;
+    const rgba = new Uint8ClampedArray([
+      v,v,v,255, v,v,v,255, v,v,v,255,
+      v,v,v,255, 200,200,200,255, v,v,v,255,
+      v,v,v,255, v,v,v,255, v,v,v,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyUnsharpMask(rgba, 3, 3, 1.0, 1, 0);
+    // center pixel should be brighter (sharpened)
+    const center = 4 * 4;
+    expect(rgba[center]).toBeGreaterThan(original[center]);
+    // alpha preserved
+    expect(rgba[center + 3]).toBe(255);
+  });
+
+  it('does not modify pixels when diff is below threshold', () => {
+    const rgba = new Uint8ClampedArray([
+      100,100,100,255, 102,102,102,255, 100,100,100,255,
+      100,100,100,255, 105,105,105,255, 100,100,100,255,
+      100,100,100,255, 102,102,102,255, 100,100,100,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyUnsharpMask(rgba, 3, 3, 1.0, 1, 50);
+    // threshold=50 means small diffs are ignored
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+
+  it('amount=0 leaves image unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      50,50,50,255, 200,200,200,255,
+      200,200,200,255, 50,50,50,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyUnsharpMask(rgba, 2, 2, 0, 1, 0);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+});
+
+describe('applyBloom', () => {
+  it('brightens pixels near bright areas', () => {
+    // 3x3: all dark except center is bright white
+    const rgba = new Uint8ClampedArray([
+      50,50,50,255, 50,50,50,255, 50,50,50,255,
+      50,50,50,255, 255,255,255,255, 50,50,50,255,
+      50,50,50,255, 50,50,50,255, 50,50,50,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyBloom(rgba, 3, 3, 200, 0.5, 1);
+    // neighbor pixels should be brighter due to bloom
+    expect(rgba[0]).toBeGreaterThan(original[0]); // top-left
+    // center should also be brighter or at max
+    expect(rgba[4 * 4]).toBeGreaterThanOrEqual(original[4 * 4]);
+    // alpha preserved
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('high threshold means no bloom when pixels are below threshold', () => {
+    const rgba = new Uint8ClampedArray([
+      50,50,50,255, 100,100,100,255,
+      100,100,100,255, 50,50,50,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyBloom(rgba, 2, 2, 250, 0.5, 1);
+    // no pixel is >= 250, so no bloom
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+
+  it('intensity=0 leaves image unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      50,50,50,255, 255,255,255,255,
+      255,255,255,255, 50,50,50,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyBloom(rgba, 2, 2, 200, 0, 1);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1551,3 +1551,103 @@ export function applyMedian(
 
   rgba.set(out);
 }
+
+/**
+ * Box blur helper — applies a simple box blur with the given radius to RGB channels.
+ * Returns a new Uint8ClampedArray with blurred RGBA data.
+ */
+function boxBlur(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  radius: number,
+): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(rgba.length);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let rSum = 0, gSum = 0, bSum = 0, count = 0;
+      for (let dy = -radius; dy <= radius; dy++) {
+        const ny = y + dy;
+        if (ny < 0 || ny >= height) continue;
+        for (let dx = -radius; dx <= radius; dx++) {
+          const nx = x + dx;
+          if (nx < 0 || nx >= width) continue;
+          const off = (ny * width + nx) * 4;
+          rSum += rgba[off];
+          gSum += rgba[off + 1];
+          bSum += rgba[off + 2];
+          count++;
+        }
+      }
+      const outOff = (y * width + x) * 4;
+      out[outOff] = (rSum / count) | 0;
+      out[outOff + 1] = (gSum / count) | 0;
+      out[outOff + 2] = (bSum / count) | 0;
+      out[outOff + 3] = rgba[outOff + 3];
+    }
+  }
+  return out;
+}
+
+/**
+ * Unsharp Mask — edge sharpening by subtracting a blurred copy from the original.
+ * output = original + amount * (original - blurred), applied only when diff >= threshold.
+ */
+export function applyUnsharpMask(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  amount: number,
+  radius: number,
+  threshold: number,
+): void {
+  radius = Math.max(1, Math.round(radius));
+  const blurred = boxBlur(rgba, width, height, radius);
+  const len = width * height * 4;
+  for (let i = 0; i < len; i += 4) {
+    for (let c = 0; c < 3; c++) {
+      const diff = rgba[i + c] - blurred[i + c];
+      if (Math.abs(diff) >= threshold) {
+        rgba[i + c] = Math.max(0, Math.min(255, rgba[i + c] + amount * diff)) | 0;
+      }
+    }
+  }
+}
+
+/**
+ * Bloom — glow effect around bright pixels.
+ * Extracts pixels above threshold, blurs them, then additively blends back.
+ */
+export function applyBloom(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  threshold: number,
+  intensity: number,
+  radius: number,
+): void {
+  radius = Math.max(1, Math.round(radius));
+  const len = width * height * 4;
+
+  // Extract bright pixels
+  const bright = new Uint8ClampedArray(len);
+  for (let i = 0; i < len; i += 4) {
+    const lum = (rgba[i] * 77 + rgba[i + 1] * 150 + rgba[i + 2] * 29) >> 8;
+    if (lum >= threshold) {
+      bright[i] = rgba[i];
+      bright[i + 1] = rgba[i + 1];
+      bright[i + 2] = rgba[i + 2];
+    }
+    bright[i + 3] = 255;
+  }
+
+  // Blur the bright pixels
+  const glowed = boxBlur(bright, width, height, radius);
+
+  // Additive blend
+  for (let i = 0; i < len; i += 4) {
+    for (let c = 0; c < 3; c++) {
+      rgba[i + c] = Math.min(255, rgba[i + c] + (glowed[i + c] * intensity) | 0);
+    }
+  }
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -273,6 +273,10 @@ export interface JP2LayerOptions {
    * 가장자리 처리: 경계 밖 픽셀은 무시 (skip) 하여 유효 이웃만으로 중앙값 계산
    */
   median?: number | { kernelSize: number };
+  /** 언샤프 마스크 에지 선명화. amount: 강도(기본 1.0), radius: 블러 반경(기본 1), threshold: 차이 임계값(기본 0) */
+  unsharpMask?: { amount?: number; radius?: number; threshold?: number };
+  /** 밝은 영역 발광(bloom) 효과. threshold: 최소 밝기(기본 200), intensity: 강도(기본 0.5), radius: 반경(기본 3) */
+  bloom?: { threshold?: number; intensity?: number; radius?: number };
 }
 
 export interface JP2LayerResult {
@@ -464,6 +468,8 @@ export async function createJP2TileLayer(
   const medianKernelSize = options?.median != null
     ? (typeof options.median === 'number' ? options.median : options.median.kernelSize)
     : undefined;
+  const unsharpMask = options?.unsharpMask;
+  const bloom = options?.bloom;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -667,6 +673,14 @@ export async function createJP2TileLayer(
 
           if (medianKernelSize != null && medianKernelSize >= 3) {
             applyMedian(decoded.data, decoded.width, decoded.height, medianKernelSize);
+          }
+
+          if (unsharpMask) {
+            applyUnsharpMask(decoded.data, decoded.width, decoded.height, unsharpMask.amount ?? 1.0, unsharpMask.radius ?? 1, unsharpMask.threshold ?? 0);
+          }
+
+          if (bloom) {
+            applyBloom(decoded.data, decoded.width, decoded.height, bloom.threshold ?? 200, bloom.intensity ?? 0.5, bloom.radius ?? 3);
           }
 
           if (sepia != null && sepia !== 0) {


### PR DESCRIPTION
## Summary
- `unsharpMask` 옵션 추가: amount/radius/threshold로 에지 선명화 제어 (closes #241)
- `bloom` 옵션 추가: threshold/intensity/radius로 밝은 영역 발광 효과 (closes #242)
- 파이프라인에서 median 이후, sepia 이전에 적용

## Test plan
- [x] `applyUnsharpMask` 단위 테스트 3개 (선명화 확인, threshold 이하 무변경, amount=0 무변경)
- [x] `applyBloom` 단위 테스트 3개 (발광 확인, 고threshold 무변경, intensity=0 무변경)
- [x] `npm test` 전체 484개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)