### PR TITLE
docs: update CHANGELOG and README for sprint 65 (unsharpMask, bloom)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 65
+
+### Added
+- **`JP2LayerOptions.unsharpMask`**: 언샤프 마스크(엣지 선명화) 옵션 추가 (closes #241, PR #243)
+  - 타입: `{ amount?: number; radius?: number; threshold?: number }`, 기본값: `undefined`
+  - amount: 선명화 강도 (0~5, 기본값 1), radius: 블러 반경 (1~10, 기본값 1), threshold: 적용 최소 차이값 (0~255, 기본값 0)
+  - `pixel-conversion.ts`의 `applyUnsharpMask()` 함수로 처리
+  - 적용 순서: median 이후, sepia 이전
+- **`JP2LayerOptions.bloom`**: 블룸(밝은 영역 발광) 효과 옵션 추가 (closes #242, PR #243)
+  - 타입: `{ threshold?: number; intensity?: number; radius?: number }`, 기본값: `undefined`
+  - threshold: 발광 적용 최소 밝기 (0~255, 기본값 200), intensity: 발광 강도 (0~1, 기본값 0.5), radius: 발광 반경 (1~10, 기본값 2)
+  - `pixel-conversion.ts`의 `applyBloom()` 함수로 처리
+  - 적용 순서: unsharpMask 이후, sepia 이전
+
+---
+
 ## [Unreleased] — Sprint 64
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `colorGrade` | `{ shadows?: [number, number, number]; highlights?: [number, number, number]; balance?: number; strength?: number }` | `undefined` | 섀도우/하이라이트 영역에 독립적 색조를 적용하는 스플릿 토닝 효과 |
 | `chromaKey` | `{ color: [number, number, number]; tolerance?: number }` | `undefined` | 특정 RGB 색상을 투명 처리 (크로마키 효과). tolerance: 유클리드 거리 허용 오차 (기본값: 0) |
 | `median` | `number \| { kernelSize: number }` | `undefined` | 중앙값 필터. kernelSize: 홀수 3~11 (짝수→+1, 범위 밖→클램프). salt-and-pepper 노이즈 제거, 엣지 보존, 가장자리 skip |
+| `unsharpMask` | `{ amount?: number; radius?: number; threshold?: number }` | `undefined` | 언샤프 마스크(엣지 선명화) 효과. amount: 강도 (0~5, 기본값 1), radius: 블러 반경 (1~10, 기본값 1), threshold: 적용 최소 차이값 (0~255, 기본값 0) |
+| `bloom` | `{ threshold?: number; intensity?: number; radius?: number }` | `undefined` | 블룸(밝은 영역 발광) 효과. threshold: 발광 적용 최소 밝기 (0~255, 기본값 200), intensity: 발광 강도 (0~1, 기본값 0.5), radius: 발광 반경 (1~10, 기본값 2) |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 65 섹션 추가: unsharpMask/bloom 옵션 추가 내용
- README API 옵션 테이블에 `unsharpMask`, `bloom` 행 추가

## 관련 PR
- 문서화 대상: PR #243 (closes #241, #242)

🤖 Generated with [Claude Code](https://claude.com/claude-code)