### PR TITLE
feat(api): add radialBlur and motionBlur options (#245, #246)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1906,5 +1906,98 @@ describe('applyBloom', () => {
     for (let i = 0; i < rgba.length; i++) {
       expect(rgba[i]).toBe(original[i]);
     }
+  });
+});
+
+describe('applyRadialBlur', () => {
+  it('blurs pixels away from center', () => {
+    // 3x3: center bright, edges dark
+    const rgba = new Uint8ClampedArray([
+      0,0,0,255,   0,0,0,255,   0,0,0,255,
+      0,0,0,255, 255,255,255,255, 0,0,0,255,
+      0,0,0,255,   0,0,0,255,   0,0,0,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyRadialBlur(rgba, 3, 3, 4);
+    // center pixel should still be brightest or unchanged (it's at the center)
+    // edge pixels may pick up some brightness from center
+    // alpha preserved
+    expect(rgba[3]).toBe(255);
+    expect(rgba[4 * 4 + 3]).toBe(255);
+  });
+
+  it('strength=1 leaves image unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      50,50,50,255, 200,200,200,255,
+      200,200,200,255, 50,50,50,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyRadialBlur(rgba, 2, 2, 1);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+
+  it('accepts custom center coordinates', () => {
+    const rgba = new Uint8ClampedArray([
+      255,0,0,255, 0,255,0,255,
+      0,0,255,255, 128,128,128,255,
+    ]);
+    // should not throw
+    applyRadialBlur(rgba, 2, 2, 4, 0.0, 0.0);
+    expect(rgba[3]).toBe(255); // alpha preserved
+  });
+});
+
+describe('applyMotionBlur', () => {
+  it('blurs horizontally by default (angle=0)', () => {
+    // 3x1 row: dark, bright, dark
+    const rgba = new Uint8ClampedArray([
+      0,0,0,255, 255,255,255,255, 0,0,0,255,
+    ]);
+    applyMotionBlur(rgba, 3, 1, 3, 0);
+    // center pixel should be averaged with neighbors
+    const center = 1 * 4;
+    expect(rgba[center]).toBeLessThan(255);
+    expect(rgba[center]).toBeGreaterThan(0);
+    // alpha preserved
+    expect(rgba[center + 3]).toBe(255);
+  });
+
+  it('strength=1 leaves image unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      50,50,50,255, 200,200,200,255,
+      200,200,200,255, 50,50,50,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyMotionBlur(rgba, 2, 2, 1, 0);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+
+  it('blurs vertically with angle=90', () => {
+    // 1x3 column: dark, bright, dark
+    const rgba = new Uint8ClampedArray([
+      0,0,0,255,
+      255,255,255,255,
+      0,0,0,255,
+    ]);
+    applyMotionBlur(rgba, 1, 3, 3, 90);
+    // center pixel should be averaged
+    const center = 1 * 4;
+    expect(rgba[center]).toBeLessThan(255);
+    expect(rgba[center]).toBeGreaterThan(0);
+    expect(rgba[center + 3]).toBe(255);
+  });
+
+  it('works with angle=45', () => {
+    const rgba = new Uint8ClampedArray([
+      255,255,255,255, 0,0,0,255,
+      0,0,0,255, 255,255,255,255,
+    ]);
+    // should not throw
+    applyMotionBlur(rgba, 2, 2, 4, 45);
+    expect(rgba[3]).toBe(255);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1651,3 +1651,97 @@ export function applyBloom(
     }
   }
 }
+
+/**
+ * Radial (zoom) blur — samples along the direction from each pixel toward the center.
+ * strength: number of samples (default 8), centerX/centerY: normalized 0–1 (default 0.5).
+ */
+export function applyRadialBlur(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  strength: number,
+  centerX: number = 0.5,
+  centerY: number = 0.5,
+): void {
+  strength = Math.max(1, Math.min(32, Math.round(strength)));
+  if (strength <= 1) return;
+  const cx = centerX * width;
+  const cy = centerY * height;
+  const out = new Uint8ClampedArray(rgba.length);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const dx = x - cx;
+      const dy = y - cy;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      // step size proportional to distance from center
+      const stepX = dist > 0 ? (dx / dist) * (dist / width) : 0;
+      const stepY = dist > 0 ? (dy / dist) * (dist / height) : 0;
+
+      let rSum = 0, gSum = 0, bSum = 0, count = 0;
+      for (let s = 0; s < strength; s++) {
+        const t = (s / (strength - 1)) - 0.5; // -0.5 to 0.5
+        const sx = Math.round(x + t * stepX * strength);
+        const sy = Math.round(y + t * stepY * strength);
+        if (sx >= 0 && sx < width && sy >= 0 && sy < height) {
+          const off = (sy * width + sx) * 4;
+          rSum += rgba[off];
+          gSum += rgba[off + 1];
+          bSum += rgba[off + 2];
+          count++;
+        }
+      }
+      out[idx] = (rSum / count) | 0;
+      out[idx + 1] = (gSum / count) | 0;
+      out[idx + 2] = (bSum / count) | 0;
+      out[idx + 3] = rgba[idx + 3];
+    }
+  }
+  rgba.set(out);
+}
+
+/**
+ * Motion blur — samples along a line at the given angle.
+ * strength: number of samples (default 8, max 32), angle: degrees (default 0 = horizontal).
+ */
+export function applyMotionBlur(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  strength: number,
+  angle: number = 0,
+): void {
+  strength = Math.max(1, Math.min(32, Math.round(strength)));
+  if (strength <= 1) return;
+  const rad = (angle * Math.PI) / 180;
+  const dirX = Math.cos(rad);
+  const dirY = Math.sin(rad);
+  const half = (strength - 1) / 2;
+  const out = new Uint8ClampedArray(rgba.length);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      let rSum = 0, gSum = 0, bSum = 0, count = 0;
+      for (let s = 0; s < strength; s++) {
+        const t = s - half;
+        const sx = Math.round(x + t * dirX);
+        const sy = Math.round(y + t * dirY);
+        if (sx >= 0 && sx < width && sy >= 0 && sy < height) {
+          const off = (sy * width + sx) * 4;
+          rSum += rgba[off];
+          gSum += rgba[off + 1];
+          bSum += rgba[off + 2];
+          count++;
+        }
+      }
+      out[idx] = (rSum / count) | 0;
+      out[idx + 1] = (gSum / count) | 0;
+      out[idx + 2] = (bSum / count) | 0;
+      out[idx + 3] = rgba[idx + 3];
+    }
+  }
+  rgba.set(out);
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -277,6 +277,10 @@ export interface JP2LayerOptions {
   unsharpMask?: { amount?: number; radius?: number; threshold?: number };
   /** 밝은 영역 발광(bloom) 효과. threshold: 최소 밝기(기본 200), intensity: 강도(기본 0.5), radius: 반경(기본 3) */
   bloom?: { threshold?: number; intensity?: number; radius?: number };
+  /** 방사형(줌) 블러 효과. number 단축 시 strength만 설정. strength: 샘플 수(기본 8), centerX/centerY: 중심점(0~1, 기본 0.5) */
+  radialBlur?: number | { strength?: number; centerX?: number; centerY?: number };
+  /** 선형 모션 블러 효과. number 단축 시 strength만 설정. strength: 샘플 수(기본 8, 최대 32), angle: 방향(도, 기본 0=수평) */
+  motionBlur?: number | { strength?: number; angle?: number };
 }
 
 export interface JP2LayerResult {
@@ -470,6 +474,16 @@ export async function createJP2TileLayer(
     : undefined;
   const unsharpMask = options?.unsharpMask;
   const bloom = options?.bloom;
+  const radialBlurOpt = options?.radialBlur != null
+    ? (typeof options.radialBlur === 'number'
+      ? { strength: options.radialBlur, centerX: 0.5, centerY: 0.5 }
+      : { strength: options.radialBlur.strength ?? 8, centerX: options.radialBlur.centerX ?? 0.5, centerY: options.radialBlur.centerY ?? 0.5 })
+    : undefined;
+  const motionBlurOpt = options?.motionBlur != null
+    ? (typeof options.motionBlur === 'number'
+      ? { strength: options.motionBlur, angle: 0 }
+      : { strength: options.motionBlur.strength ?? 8, angle: options.motionBlur.angle ?? 0 })
+    : undefined;
 
   // Progress tracking state
   let progressTotal = 0;
@@ -681,6 +695,14 @@ export async function createJP2TileLayer(
 
           if (bloom) {
             applyBloom(decoded.data, decoded.width, decoded.height, bloom.threshold ?? 200, bloom.intensity ?? 0.5, bloom.radius ?? 3);
+          }
+
+          if (radialBlurOpt) {
+            applyRadialBlur(decoded.data, decoded.width, decoded.height, radialBlurOpt.strength, radialBlurOpt.centerX, radialBlurOpt.centerY);
+          }
+
+          if (motionBlurOpt) {
+            applyMotionBlur(decoded.data, decoded.width, decoded.height, motionBlurOpt.strength, motionBlurOpt.angle);
           }
 
           if (sepia != null && sepia !== 0) {


### PR DESCRIPTION
## Summary
- `radialBlur` 옵션 추가: 중심점 기준 방사형 줌 블러 효과 (number 단축 및 객체 형식 지원)
- `motionBlur` 옵션 추가: 특정 각도의 선형 모션 블러 효과 (number 단축 및 객체 형식 지원)
- 단위 테스트 7개 추가 (radialBlur 3개, motionBlur 4개)

closes #245
closes #246

## Test plan
- [x] `npm test` 491개 전체 통과
- [ ] radialBlur: number 단축 표기 및 객체 형식 동작 확인
- [ ] motionBlur: number 단축 표기 및 객체 형식 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)