### PR TITLE
docs: update CHANGELOG and README for sprint 66 (radialBlur, motionBlur)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 66
+
+### Added
+- **`JP2LayerOptions.radialBlur`**: 방사형 줌 블러 효과 옵션 추가 (closes #245, PR #247)
+  - 타입: `number | { amount?: number; centerX?: number; centerY?: number }`, 기본값: `undefined`
+  - `number` 단축 표기 시 amount로 직접 사용
+  - amount: 블러 강도/샘플 수 (기본값 10), centerX/centerY: 중심점 (0~1, 기본값 0.5)
+  - `pixel-conversion.ts`의 `applyRadialBlur()` 함수로 처리
+  - 적용 순서: bloom 이후
+- **`JP2LayerOptions.motionBlur`**: 선형 모션 블러 효과 옵션 추가 (closes #246, PR #247)
+  - 타입: `number | { distance?: number; angle?: number }`, 기본값: `undefined`
+  - `number` 단축 표기 시 distance로 직접 사용
+  - distance: 블러 거리/샘플 수 (기본값 10), angle: 블러 방향 각도 (도, 기본값 0)
+  - `pixel-conversion.ts`의 `applyMotionBlur()` 함수로 처리
+  - 적용 순서: radialBlur 이후
+
+---
+
 ## [Unreleased] — Sprint 65
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `median` | `number \| { kernelSize: number }` | `undefined` | 중앙값 필터. kernelSize: 홀수 3~11 (짝수→+1, 범위 밖→클램프). salt-and-pepper 노이즈 제거, 엣지 보존, 가장자리 skip |
 | `unsharpMask` | `{ amount?: number; radius?: number; threshold?: number }` | `undefined` | 언샤프 마스크(엣지 선명화) 효과. amount: 강도 (0~5, 기본값 1), radius: 블러 반경 (1~10, 기본값 1), threshold: 적용 최소 차이값 (0~255, 기본값 0) |
 | `bloom` | `{ threshold?: number; intensity?: number; radius?: number }` | `undefined` | 블룸(밝은 영역 발광) 효과. threshold: 발광 적용 최소 밝기 (0~255, 기본값 200), intensity: 발광 강도 (0~1, 기본값 0.5), radius: 발광 반경 (1~10, 기본값 2) |
+| `radialBlur` | `number \| { amount?: number; centerX?: number; centerY?: number }` | `undefined` | 방사형 줌 블러 효과. amount: 블러 강도/샘플 수 (기본값 10), centerX/centerY: 중심점 (0~1, 기본값 0.5). `number` 단축 표기 시 amount로 사용 |
+| `motionBlur` | `number \| { distance?: number; angle?: number }` | `undefined` | 선형 모션 블러 효과. distance: 블러 거리/샘플 수 (기본값 10), angle: 블러 방향 각도 (도, 기본값 0). `number` 단축 표기 시 distance로 사용 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 66 섹션 추가: radialBlur/motionBlur 옵션 추가 내용
- README API 옵션 테이블에 `radialBlur`, `motionBlur` 행 추가

## 관련 PR
- 문서화 대상: PR #247 (closes #245, #246)

🤖 Generated with [Claude Code](https://claude.com/claude-code)