### PR TITLE
feat(api): add pencilSketch and oilPaint options (#249, #250)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur, applyPencilSketch, applyOilPaint } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -1998,6 +1998,122 @@ describe('applyMotionBlur', () => {
     ]);
     // should not throw
     applyMotionBlur(rgba, 2, 2, 4, 45);
+    expect(rgba[3]).toBe(255);
+  });
+});
+
+describe('applyPencilSketch', () => {
+  it('modifies pixel values with default settings', () => {
+    const rgba = new Uint8ClampedArray([
+      100,150,200,255, 50,80,120,255,
+      200,100,50,255, 10,20,30,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyPencilSketch(rgba, 2, 2);
+    let changed = false;
+    for (let i = 0; i < rgba.length; i++) {
+      if (i % 4 !== 3 && rgba[i] !== original[i]) { changed = true; break; }
+    }
+    expect(changed).toBe(true);
+    // alpha preserved
+    expect(rgba[3]).toBe(255);
+    expect(rgba[7]).toBe(255);
+  });
+
+  it('preserves alpha channel', () => {
+    const rgba = new Uint8ClampedArray([
+      100,100,100,128, 200,200,200,64,
+      50,50,50,255, 150,150,150,0,
+    ]);
+    applyPencilSketch(rgba, 2, 2);
+    expect(rgba[3]).toBe(128);
+    expect(rgba[7]).toBe(64);
+    expect(rgba[11]).toBe(255);
+    expect(rgba[15]).toBe(0);
+  });
+
+  it('works with screen blend mode', () => {
+    const rgba = new Uint8ClampedArray([
+      100,150,200,255, 50,80,120,255,
+      200,100,50,255, 10,20,30,255,
+    ]);
+    // should not throw
+    applyPencilSketch(rgba, 2, 2, 1.0, 'screen');
+    expect(rgba[3]).toBe(255);
+  });
+
+  it('intensity=0 leaves image mostly unchanged', () => {
+    const rgba = new Uint8ClampedArray([
+      100,150,200,255, 50,80,120,255,
+      200,100,50,255, 10,20,30,255,
+    ]);
+    const original = new Uint8ClampedArray(rgba);
+    applyPencilSketch(rgba, 2, 2, 0);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(Math.abs(rgba[i] - original[i])).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('applyOilPaint', () => {
+  it('modifies pixel values', () => {
+    // 4x4 image with varied colors
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = i * 16;
+      rgba[i * 4 + 1] = 255 - i * 16;
+      rgba[i * 4 + 2] = (i * 37) % 256;
+      rgba[i * 4 + 3] = 255;
+    }
+    const original = new Uint8ClampedArray(rgba);
+    applyOilPaint(rgba, 4, 4);
+    let changed = false;
+    for (let i = 0; i < rgba.length; i++) {
+      if (i % 4 !== 3 && rgba[i] !== original[i]) { changed = true; break; }
+    }
+    expect(changed).toBe(true);
+  });
+
+  it('preserves alpha channel', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = i * 16;
+      rgba[i * 4 + 1] = 128;
+      rgba[i * 4 + 2] = 64;
+      rgba[i * 4 + 3] = i * 10;
+    }
+    const alphas = Array.from({length: 16}, (_, i) => rgba[i * 4 + 3]);
+    applyOilPaint(rgba, 4, 4);
+    for (let i = 0; i < 16; i++) {
+      expect(rgba[i * 4 + 3]).toBe(alphas[i]);
+    }
+  });
+
+  it('uniform image stays unchanged', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = 100;
+      rgba[i * 4 + 1] = 100;
+      rgba[i * 4 + 2] = 100;
+      rgba[i * 4 + 3] = 255;
+    }
+    const original = new Uint8ClampedArray(rgba);
+    applyOilPaint(rgba, 4, 4, 2, 8);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+
+  it('works with custom radius and levels', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = i * 16;
+      rgba[i * 4 + 1] = 128;
+      rgba[i * 4 + 2] = 64;
+      rgba[i * 4 + 3] = 255;
+    }
+    // should not throw
+    applyOilPaint(rgba, 4, 4, 3, 6);
     expect(rgba[3]).toBe(255);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1745,3 +1745,124 @@ export function applyMotionBlur(
   }
   rgba.set(out);
 }
+
+/**
+ * Pencil sketch effect — grayscale → invert → blur → dodge blend with original gray.
+ * intensity: effect strength (default 1.0), blendMode: 'multiply' or 'screen' (default 'multiply').
+ */
+export function applyPencilSketch(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  intensity: number = 1.0,
+  blendMode: 'multiply' | 'screen' = 'multiply',
+): void {
+  const len = width * height;
+  // Step 1: compute grayscale
+  const gray = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    const off = i * 4;
+    gray[i] = (0.299 * rgba[off] + 0.587 * rgba[off + 1] + 0.114 * rgba[off + 2]) | 0;
+  }
+  // Step 2: invert grayscale
+  const inverted = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    inverted[i] = 255 - gray[i];
+  }
+  // Step 3: blur inverted (box blur radius 5)
+  const blurRadius = 5;
+  const blurred = new Uint8Array(len);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let sum = 0, count = 0;
+      for (let dy = -blurRadius; dy <= blurRadius; dy++) {
+        const ny = y + dy;
+        if (ny < 0 || ny >= height) continue;
+        for (let dx = -blurRadius; dx <= blurRadius; dx++) {
+          const nx = x + dx;
+          if (nx < 0 || nx >= width) continue;
+          sum += inverted[ny * width + nx];
+          count++;
+        }
+      }
+      blurred[y * width + x] = (sum / count) | 0;
+    }
+  }
+  // Step 4: dodge blend — gray / (255 - blurred) * 255
+  const sketch = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    const denom = 255 - blurred[i];
+    sketch[i] = denom === 0 ? 255 : Math.min(255, (gray[i] * 255 / denom) | 0);
+  }
+  // Step 5: apply to RGBA with intensity and blend mode
+  for (let i = 0; i < len; i++) {
+    const off = i * 4;
+    const s = sketch[i];
+    for (let c = 0; c < 3; c++) {
+      const orig = rgba[off + c];
+      let blended: number;
+      if (blendMode === 'multiply') {
+        blended = (s * orig / 255) | 0;
+      } else {
+        blended = 255 - ((255 - s) * (255 - orig) / 255) | 0;
+      }
+      rgba[off + c] = Math.min(255, Math.max(0, (orig + (blended - orig) * intensity) | 0));
+    }
+  }
+}
+
+/**
+ * Oil paint effect — for each pixel, quantize neighbor brightness into levels,
+ * find the most frequent level, and output the average color of that level's pixels.
+ */
+export function applyOilPaint(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  radius: number = 4,
+  levels: number = 8,
+): void {
+  radius = Math.max(1, Math.min(10, Math.round(radius)));
+  levels = Math.max(2, Math.min(64, Math.round(levels)));
+  const out = new Uint8ClampedArray(rgba.length);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const counts = new Int32Array(levels);
+      const rSums = new Float64Array(levels);
+      const gSums = new Float64Array(levels);
+      const bSums = new Float64Array(levels);
+
+      for (let dy = -radius; dy <= radius; dy++) {
+        const ny = y + dy;
+        if (ny < 0 || ny >= height) continue;
+        for (let dx = -radius; dx <= radius; dx++) {
+          const nx = x + dx;
+          if (nx < 0 || nx >= width) continue;
+          const off = (ny * width + nx) * 4;
+          const lum = (0.299 * rgba[off] + 0.587 * rgba[off + 1] + 0.114 * rgba[off + 2]) | 0;
+          const level = Math.min(levels - 1, (lum * levels / 256) | 0);
+          counts[level]++;
+          rSums[level] += rgba[off];
+          gSums[level] += rgba[off + 1];
+          bSums[level] += rgba[off + 2];
+        }
+      }
+
+      let maxCount = 0, maxLevel = 0;
+      for (let l = 0; l < levels; l++) {
+        if (counts[l] > maxCount) {
+          maxCount = counts[l];
+          maxLevel = l;
+        }
+      }
+
+      out[idx] = (rSums[maxLevel] / maxCount) | 0;
+      out[idx + 1] = (gSums[maxLevel] / maxCount) | 0;
+      out[idx + 2] = (bSums[maxLevel] / maxCount) | 0;
+      out[idx + 3] = rgba[idx + 3];
+    }
+  }
+  rgba.set(out);
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur, applyPencilSketch, applyOilPaint } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -281,6 +281,10 @@ export interface JP2LayerOptions {
   radialBlur?: number | { strength?: number; centerX?: number; centerY?: number };
   /** 선형 모션 블러 효과. number 단축 시 strength만 설정. strength: 샘플 수(기본 8, 최대 32), angle: 방향(도, 기본 0=수평) */
   motionBlur?: number | { strength?: number; angle?: number };
+  /** 연필 스케치 효과. true 시 기본값 적용. intensity: 강도(기본 1.0), blendMode: 블렌드 모드(기본 'multiply') */
+  pencilSketch?: boolean | { intensity?: number; blendMode?: 'multiply' | 'screen' };
+  /** 유화 페인팅 효과. true 시 기본값 적용. radius: 커널 반경(기본 4), levels: 밝기 양자화 레벨(기본 8) */
+  oilPaint?: boolean | { radius?: number; levels?: number };
 }
 
 export interface JP2LayerResult {
@@ -483,6 +487,20 @@ export async function createJP2TileLayer(
     ? (typeof options.motionBlur === 'number'
       ? { strength: options.motionBlur, angle: 0 }
       : { strength: options.motionBlur.strength ?? 8, angle: options.motionBlur.angle ?? 0 })
+    : undefined;
+  const pencilSketchOpt = options?.pencilSketch != null
+    ? (options.pencilSketch === true
+      ? { intensity: 1.0, blendMode: 'multiply' as const }
+      : options.pencilSketch === false
+        ? undefined
+        : { intensity: options.pencilSketch.intensity ?? 1.0, blendMode: options.pencilSketch.blendMode ?? 'multiply' as const })
+    : undefined;
+  const oilPaintOpt = options?.oilPaint != null
+    ? (options.oilPaint === true
+      ? { radius: 4, levels: 8 }
+      : options.oilPaint === false
+        ? undefined
+        : { radius: options.oilPaint.radius ?? 4, levels: options.oilPaint.levels ?? 8 })
     : undefined;
 
   // Progress tracking state
@@ -703,6 +721,14 @@ export async function createJP2TileLayer(
 
           if (motionBlurOpt) {
             applyMotionBlur(decoded.data, decoded.width, decoded.height, motionBlurOpt.strength, motionBlurOpt.angle);
+          }
+
+          if (pencilSketchOpt) {
+            applyPencilSketch(decoded.data, decoded.width, decoded.height, pencilSketchOpt.intensity, pencilSketchOpt.blendMode);
+          }
+
+          if (oilPaintOpt) {
+            applyOilPaint(decoded.data, decoded.width, decoded.height, oilPaintOpt.radius, oilPaintOpt.levels);
           }
 
           if (sepia != null && sepia !== 0) {


### PR DESCRIPTION
## Summary
- `pencilSketch` 옵션 추가: 그레이스케일→반전→블러→Dodge 블렌드 기반 연필 스케치 효과 (`boolean | { intensity?, blendMode? }`)
- `oilPaint` 옵션 추가: 커널 내 밝기 양자화 기반 유화 페인팅 효과 (`boolean | { radius?, levels? }`)
- 파이프라인에서 motionBlur 이후 순서로 적용
- 단위 테스트 8개 추가 (총 499개 통과)

closes #249
closes #250

## Test plan
- [x] `npm test` 통과 (499 tests)
- [ ] `pencilSketch: true` 및 `pencilSketch: { intensity: 1.5, blendMode: 'screen' }` 동작 확인
- [ ] `oilPaint: true` 및 `oilPaint: { radius: 3, levels: 6 }` 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)