### PR TITLE
feat(api): add kuwahara and crystallize options (#253, #254)

### DIFF
--- a/src/pixel-conversion.test.ts
+++ b/src/pixel-conversion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur, applyPencilSketch, applyOilPaint } from './pixel-conversion';
+import { decodedBufferToRGBA, computeMinMax, applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur, applyPencilSketch, applyOilPaint, applyKuwahara, applyCrystallize } from './pixel-conversion';
 
 describe('decodedBufferToRGBA', () => {
   it('8-bit, 3ch: RGB to RGBA with alpha=255', () => {
@@ -2114,6 +2114,111 @@ describe('applyOilPaint', () => {
     }
     // should not throw
     applyOilPaint(rgba, 4, 4, 3, 6);
+    expect(rgba[3]).toBe(255);
+  });
+});
+
+describe('applyKuwahara', () => {
+  it('smooths noisy pixel using lowest-variance quadrant', () => {
+    // 3x3 image: uniform 100 except center is 200
+    const v = 100;
+    const rgba = new Uint8ClampedArray([
+      v,v,v,255, v,v,v,255, v,v,v,255,
+      v,v,v,255, 200,200,200,255, v,v,v,255,
+      v,v,v,255, v,v,v,255, v,v,v,255,
+    ]);
+    applyKuwahara(rgba, 3, 3, 1);
+    // center pixel should be smoothed toward 100
+    const center = 4 * 4;
+    expect(rgba[center]).toBeLessThan(200);
+  });
+
+  it('preserves uniform image', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = 100; rgba[i * 4 + 1] = 100; rgba[i * 4 + 2] = 100; rgba[i * 4 + 3] = 255;
+    }
+    const original = new Uint8ClampedArray(rgba);
+    applyKuwahara(rgba, 4, 4, 2);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+
+  it('preserves alpha channel', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = i * 16; rgba[i * 4 + 1] = 128; rgba[i * 4 + 2] = 64; rgba[i * 4 + 3] = i * 10;
+    }
+    const alphas = Array.from({length: 16}, (_, i) => rgba[i * 4 + 3]);
+    applyKuwahara(rgba, 4, 4, 2);
+    for (let i = 0; i < 16; i++) {
+      expect(rgba[i * 4 + 3]).toBe(alphas[i]);
+    }
+  });
+
+  it('modifies pixel values on varied image', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = i * 16; rgba[i * 4 + 1] = 255 - i * 16; rgba[i * 4 + 2] = (i * 37) % 256; rgba[i * 4 + 3] = 255;
+    }
+    const original = new Uint8ClampedArray(rgba);
+    applyKuwahara(rgba, 4, 4, 2);
+    let changed = false;
+    for (let i = 0; i < rgba.length; i++) {
+      if (i % 4 !== 3 && rgba[i] !== original[i]) { changed = true; break; }
+    }
+    expect(changed).toBe(true);
+  });
+});
+
+describe('applyCrystallize', () => {
+  it('creates mosaic effect — reduces unique colors', () => {
+    // 8x8 image with gradient
+    const rgba = new Uint8ClampedArray(8 * 8 * 4);
+    for (let i = 0; i < 64; i++) {
+      rgba[i * 4] = i * 4; rgba[i * 4 + 1] = 128; rgba[i * 4 + 2] = 255 - i * 4; rgba[i * 4 + 3] = 255;
+    }
+    applyCrystallize(rgba, 8, 8, 4);
+    // Count unique colors — should be fewer than 64
+    const colors = new Set<string>();
+    for (let i = 0; i < 64; i++) {
+      colors.add(`${rgba[i*4]},${rgba[i*4+1]},${rgba[i*4+2]}`);
+    }
+    expect(colors.size).toBeLessThan(64);
+  });
+
+  it('preserves alpha channel', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = i * 16; rgba[i * 4 + 1] = 128; rgba[i * 4 + 2] = 64; rgba[i * 4 + 3] = i * 10;
+    }
+    const alphas = Array.from({length: 16}, (_, i) => rgba[i * 4 + 3]);
+    applyCrystallize(rgba, 4, 4, 2);
+    for (let i = 0; i < 16; i++) {
+      expect(rgba[i * 4 + 3]).toBe(alphas[i]);
+    }
+  });
+
+  it('uniform image stays unchanged', () => {
+    const rgba = new Uint8ClampedArray(4 * 4 * 4);
+    for (let i = 0; i < 16; i++) {
+      rgba[i * 4] = 100; rgba[i * 4 + 1] = 100; rgba[i * 4 + 2] = 100; rgba[i * 4 + 3] = 255;
+    }
+    const original = new Uint8ClampedArray(rgba);
+    applyCrystallize(rgba, 4, 4, 2);
+    for (let i = 0; i < rgba.length; i++) {
+      expect(rgba[i]).toBe(original[i]);
+    }
+  });
+
+  it('works with custom cellSize', () => {
+    const rgba = new Uint8ClampedArray(8 * 8 * 4);
+    for (let i = 0; i < 64; i++) {
+      rgba[i * 4] = i * 4; rgba[i * 4 + 1] = 128; rgba[i * 4 + 2] = 64; rgba[i * 4 + 3] = 255;
+    }
+    // should not throw
+    applyCrystallize(rgba, 8, 8, 8);
     expect(rgba[3]).toBe(255);
   });
 });

--- a/src/pixel-conversion.ts
+++ b/src/pixel-conversion.ts
@@ -1866,3 +1866,134 @@ export function applyOilPaint(
   }
   rgba.set(out);
 }
+
+/**
+ * Kuwahara filter — edge-preserving noise reduction with painting effect.
+ * Divides each pixel's neighborhood into 4 overlapping quadrants,
+ * computes variance for each, and outputs the mean of the lowest-variance quadrant.
+ */
+export function applyKuwahara(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  radius: number = 3,
+): void {
+  radius = Math.max(1, Math.min(10, Math.round(radius)));
+  const out = new Uint8ClampedArray(rgba.length);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+
+      const quadrants = [
+        { y0: -radius, y1: 0, x0: -radius, x1: 0 },
+        { y0: -radius, y1: 0, x0: 0, x1: radius },
+        { y0: 0, y1: radius, x0: -radius, x1: 0 },
+        { y0: 0, y1: radius, x0: 0, x1: radius },
+      ];
+
+      let bestVar = Infinity;
+      let bestR = 0, bestG = 0, bestB = 0;
+
+      for (const q of quadrants) {
+        let rSum = 0, gSum = 0, bSum = 0, rSq = 0, gSq = 0, bSq = 0, count = 0;
+        for (let dy = q.y0; dy <= q.y1; dy++) {
+          const ny = y + dy;
+          if (ny < 0 || ny >= height) continue;
+          for (let dx = q.x0; dx <= q.x1; dx++) {
+            const nx = x + dx;
+            if (nx < 0 || nx >= width) continue;
+            const off = (ny * width + nx) * 4;
+            const r = rgba[off], g = rgba[off + 1], b = rgba[off + 2];
+            rSum += r; gSum += g; bSum += b;
+            rSq += r * r; gSq += g * g; bSq += b * b;
+            count++;
+          }
+        }
+        if (count === 0) continue;
+        const variance = (rSq - rSum * rSum / count + gSq - gSum * gSum / count + bSq - bSum * bSum / count) / count;
+        if (variance < bestVar) {
+          bestVar = variance;
+          bestR = (rSum / count) | 0;
+          bestG = (gSum / count) | 0;
+          bestB = (bSum / count) | 0;
+        }
+      }
+
+      out[idx] = bestR;
+      out[idx + 1] = bestG;
+      out[idx + 2] = bestB;
+      out[idx + 3] = rgba[idx + 3];
+    }
+  }
+  rgba.set(out);
+}
+
+/**
+ * Crystallize — Voronoi-based mosaic effect.
+ * Generates seed points in a grid with jitter, then assigns each pixel
+ * the color of its nearest seed point.
+ */
+export function applyCrystallize(
+  rgba: Uint8ClampedArray,
+  width: number,
+  height: number,
+  cellSize: number = 10,
+): void {
+  cellSize = Math.max(2, Math.min(100, Math.round(cellSize)));
+
+  const cols = Math.ceil(width / cellSize);
+  const rows = Math.ceil(height / cellSize);
+  const seeds: Array<{ x: number; y: number; r: number; g: number; b: number }> = [];
+
+  const hash = (a: number, b: number) => {
+    let h = (a * 2654435761 + b * 2246822519) | 0;
+    h = ((h >> 16) ^ h) * 0x45d9f3b | 0;
+    h = ((h >> 16) ^ h) * 0x45d9f3b | 0;
+    return ((h >> 16) ^ h) & 0x7fffffff;
+  };
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      const jx = (hash(col, row) % cellSize) - cellSize / 2;
+      const jy = (hash(col + 1000, row + 1000) % cellSize) - cellSize / 2;
+      const sx = Math.max(0, Math.min(width - 1, Math.round(col * cellSize + cellSize / 2 + jx * 0.5)));
+      const sy = Math.max(0, Math.min(height - 1, Math.round(row * cellSize + cellSize / 2 + jy * 0.5)));
+      const off = (sy * width + sx) * 4;
+      seeds.push({ x: sx, y: sy, r: rgba[off], g: rgba[off + 1], b: rgba[off + 2] });
+    }
+  }
+
+  const out = new Uint8ClampedArray(rgba.length);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const cellCol = Math.floor(x / cellSize);
+      const cellRow = Math.floor(y / cellSize);
+      let minDist = Infinity;
+      let bestSeed = seeds[0];
+
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const cr = cellRow + dr;
+          const cc = cellCol + dc;
+          if (cr < 0 || cr >= rows || cc < 0 || cc >= cols) continue;
+          const seed = seeds[cr * cols + cc];
+          const ddx = x - seed.x;
+          const ddy = y - seed.y;
+          const dist = ddx * ddx + ddy * ddy;
+          if (dist < minDist) {
+            minDist = dist;
+            bestSeed = seed;
+          }
+        }
+      }
+
+      out[idx] = bestSeed.r;
+      out[idx + 1] = bestSeed.g;
+      out[idx + 2] = bestSeed.b;
+      out[idx + 3] = rgba[idx + 3];
+    }
+  }
+  rgba.set(out);
+}

--- a/src/source.ts
+++ b/src/source.ts
@@ -10,7 +10,7 @@ import type { BackgroundColor } from 'ol/layer/Base';
 import type { TileProvider, TileProviderInfo, GeoInfo } from './tile-provider';
 import { RangeTileProvider } from './range-tile-provider';
 import { debugLog, debugWarn, debugError } from './debug-logger';
-import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur, applyPencilSketch, applyOilPaint } from './pixel-conversion';
+import { applyNodata, applyGamma, applyBrightness, applyContrast, applySaturation, applyHue, applyInvert, applyThreshold, applyColorize, applySharpen, applyBlur, applySepia, applyGrayscale, applyColorMap, validateColorMap, applyPosterize, applyVignette, applyEdgeDetect, applyEmboss, applyPixelate, applyChannelSwap, applyColorBalance, applyExposure, applyLevels, validateLevels, applyNoise, applyTint, applyOutputLevels, validateOutputLevels, applyTemperature, applyFlip, applyVibrance, applyCurves, validateCurves, applyDuotone, applyDodge, applyBurn, applySolarize, applyShadowsHighlights, applyClarity, applyCrossProcess, applyGrainFilm, applyHalftone, applyHistogramEqualize, applyColorGrade, applyColorMatrix, applyAutoContrast, applyChromaKey, applyMedian, applyUnsharpMask, applyBloom, applyRadialBlur, applyMotionBlur, applyPencilSketch, applyOilPaint, applyKuwahara, applyCrystallize } from './pixel-conversion';
 
 async function ensureProjection(
   epsgCode: number,
@@ -285,6 +285,10 @@ export interface JP2LayerOptions {
   pencilSketch?: boolean | { intensity?: number; blendMode?: 'multiply' | 'screen' };
   /** 유화 페인팅 효과. true 시 기본값 적용. radius: 커널 반경(기본 4), levels: 밝기 양자화 레벨(기본 8) */
   oilPaint?: boolean | { radius?: number; levels?: number };
+  /** 쿠와하라 노이즈 감소 페인팅 필터. true 시 기본값 적용. radius: 커널 반경(기본 3) */
+  kuwahara?: boolean | { radius?: number };
+  /** 크리스탈 타일 모자이크 효과. true 시 기본값 적용. cellSize: 셀 평균 크기(기본 10, 픽셀 단위) */
+  crystallize?: boolean | { cellSize?: number };
 }
 
 export interface JP2LayerResult {
@@ -501,6 +505,20 @@ export async function createJP2TileLayer(
       : options.oilPaint === false
         ? undefined
         : { radius: options.oilPaint.radius ?? 4, levels: options.oilPaint.levels ?? 8 })
+    : undefined;
+  const kuwaharaOpt = options?.kuwahara != null
+    ? (options.kuwahara === true
+      ? { radius: 3 }
+      : options.kuwahara === false
+        ? undefined
+        : { radius: options.kuwahara.radius ?? 3 })
+    : undefined;
+  const crystallizeOpt = options?.crystallize != null
+    ? (options.crystallize === true
+      ? { cellSize: 10 }
+      : options.crystallize === false
+        ? undefined
+        : { cellSize: options.crystallize.cellSize ?? 10 })
     : undefined;
 
   // Progress tracking state
@@ -729,6 +747,14 @@ export async function createJP2TileLayer(
 
           if (oilPaintOpt) {
             applyOilPaint(decoded.data, decoded.width, decoded.height, oilPaintOpt.radius, oilPaintOpt.levels);
+          }
+
+          if (kuwaharaOpt) {
+            applyKuwahara(decoded.data, decoded.width, decoded.height, kuwaharaOpt.radius);
+          }
+
+          if (crystallizeOpt) {
+            applyCrystallize(decoded.data, decoded.width, decoded.height, crystallizeOpt.cellSize);
           }
 
           if (sepia != null && sepia !== 0) {


### PR DESCRIPTION
## Summary
- `kuwahara` 옵션 추가: 에지 보존 노이즈 감소 페인팅 필터 (4사분면 분산 기반)
- `crystallize` 옵션 추가: 보로노이 기반 크리스탈 타일 모자이크 효과
- 단위 테스트 8개 추가 (총 507개 통과)

closes #253
closes #254

## Test plan
- [x] `npm test` 통과 (507 tests)
- [ ] Reviewer: kuwahara 필터 엣지 보존 및 노이즈 감소 동작 확인
- [ ] Reviewer: crystallize 보로노이 셀 분할 및 색상 할당 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)