### PR TITLE
docs: update CHANGELOG and README for sprint 68 (kuwahara, crystallize)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `pixel-conversion.ts`의 `applyKuwahara()` 함수로 처리
   - 적용 순서: oilPaint 이후
 - **`JP2LayerOptions.crystallize`**: 크리스탈 타일 모자이크 효과 옵션 추가 (closes #254, PR #255)
-  - 타입: `boolean | { numCells?: number }`, 기본값: `undefined`
+  - 타입: `boolean | { cellSize?: number }`, 기본값: `undefined`
   - 보로노이 다이어그램 기반 크리스탈 모자이크 효과
-  - numCells: 크리스탈 셀 수 (기본값 100)
+  - cellSize: 크리스탈 셀 평균 크기 (기본값 10, 픽셀 단위)
   - `pixel-conversion.ts`의 `applyCrystallize()` 함수로 처리
   - 적용 순서: kuwahara 이후
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `pencilSketch` | `boolean \| { intensity?: number; blendMode?: 'multiply' \| 'screen' }` | `undefined` | 연필 스케치 효과. intensity: 효과 강도 (기본값 1.0), blendMode: 블렌드 모드 ('multiply' 또는 'screen', 기본값 'multiply') |
 | `oilPaint` | `boolean \| { radius?: number; levels?: number }` | `undefined` | 유화 페인팅 효과. radius: 커널 반경 (기본값 4), levels: 밝기 양자화 레벨 (기본값 8) |
 | `kuwahara` | `boolean \| { radius?: number }` | `undefined` | 쿠와하라 노이즈 감소 페인팅 필터. radius: 커널 반경 (기본값 3). 4사분면 분산 기반 에지 보존 필터 |
-| `crystallize` | `boolean \| { numCells?: number }` | `undefined` | 크리스탈 모자이크 효과. numCells: 크리스탈 셀 수 (기본값 100). 보로노이 다이어그램 기반 효과 |
+| `crystallize` | `boolean \| { cellSize?: number }` | `undefined` | 크리스탈 모자이크 효과. cellSize: 크리스탈 셀 평균 크기 (기본값 10, 픽셀 단위). 보로노이 다이어그램 기반 효과 |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG Sprint 68 섹션의 `crystallize` 옵션 파라미터 수정: `numCells` → `cellSize` (실제 구현과 일치)
- README API 옵션 테이블의 `crystallize` 행 수정: `numCells` → `cellSize`, 기본값 100 → 10

## 관련 PR
- 문서화 대상: PR #255 (closes #253, #254)

🤖 Generated with [Claude Code](https://claude.com/claude-code)