### PR TITLE
docs: update CHANGELOG and README for sprint 70 (watercolor, glitch options)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] — Sprint 70
+
+### Added
+- **`JP2LayerOptions.watercolor`**: 수채화 페인팅 효과 옵션 추가 (closes #261, PR #263)
+  - 타입: `boolean | { radius?: number; intensity?: number }`, 기본값: `undefined`
+  - 에지 검출 + 소프트 블러 + 색상 확산 기법의 수채화 페인팅 효과
+  - radius: 블러 반경 (기본값 3)
+  - intensity: 색상 확산 강도 (기본값 0.5)
+  - `pixel-conversion.ts`의 `applyWatercolor()` 함수로 처리
+  - 적용 순서: ripple 이후, sepia 이전
+- **`JP2LayerOptions.glitch`**: 디지털 글리치 효과 옵션 추가 (closes #262, PR #263)
+  - 타입: `boolean | { amount?: number; slices?: number; seed?: number }`, 기본값: `undefined`
+  - RGB 채널 시프트 + 수평 슬라이스 왜곡의 디지털 글리치 효과
+  - amount: RGB 채널 시프트 강도 (기본값 10, 픽셀 단위)
+  - slices: 수평 슬라이스 수 (기본값 8)
+  - seed: 난수 시드 (기본값 0)
+  - `pixel-conversion.ts`의 `applyGlitch()` 함수로 처리
+  - 적용 순서: watercolor 이후, sepia 이전
+
+---
+
 ## [Unreleased] — Sprint 69
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ const result = await createJP2TileLayer('path/to/file.jp2', options);
 | `crystallize` | `boolean \| { cellSize?: number }` | `undefined` | 크리스탈 모자이크 효과. cellSize: 크리스탈 셀 크기 (기본값 10). 보로노이 다이어그램 기반 효과 |
 | `swirl` | `boolean \| { angle?: number; radius?: number }` | `undefined` | 소용돌이 왜곡 효과. angle: 최대 회전 각도(라디안, 기본값 π), radius: 왜곡 반경(픽셀, 기본값 이미지 단변의 절반) |
 | `ripple` | `boolean \| { amplitudeX?: number; amplitudeY?: number; frequencyX?: number; frequencyY?: number }` | `undefined` | 물결 파동 왜곡 효과. amplitudeX/Y: X/Y축 진폭(픽셀, 기본값 10), frequencyX/Y: X/Y축 주파수(기본값 0.1) |
+| `watercolor` | `boolean \| { radius?: number; intensity?: number }` | `undefined` | 수채화 페인팅 효과. radius: 블러 반경 (기본값 3), intensity: 색상 확산 강도 (기본값 0.5). 에지 검출 + 소프트 블러 + 색상 확산 기법 |
+| `glitch` | `boolean \| { amount?: number; slices?: number; seed?: number }` | `undefined` | 디지털 글리치 효과. amount: RGB 채널 시프트 강도 (기본값 10), slices: 수평 슬라이스 수 (기본값 8), seed: 난수 시드 (기본값 0) |
 
 #### 반환값 (`JP2LayerResult`)
 


### PR DESCRIPTION
## Summary
- CHANGELOG에 Sprint 70 섹션 추가: `watercolor`, `glitch` 옵션 (closes #261, #262, PR #263)
- README API 옵션 테이블에 `watercolor`, `glitch` 항목 추가

## Test plan
- [ ] CHANGELOG 형식 및 내용 확인
- [ ] README 옵션 테이블 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)